### PR TITLE
Refactor client to separate HTTP and WebSocket logic

### DIFF
--- a/LoxNetSharp/LoxNet.csproj
+++ b/LoxNetSharp/LoxNet.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/LoxNetSharp/LoxoneClient.cs
+++ b/LoxNetSharp/LoxoneClient.cs
@@ -1,0 +1,19 @@
+namespace LoxNet;
+
+public class LoxoneClient : IAsyncDisposable
+{
+    public LoxoneHttpClient Http { get; }
+    public LoxoneWebSocketClient WebSocket { get; }
+
+    public LoxoneClient(string host, int port = 80, bool secure = false)
+    {
+        Http = new LoxoneHttpClient(host, port, secure);
+        WebSocket = new LoxoneWebSocketClient(host, port, secure, Http);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Http.DisposeAsync();
+        await WebSocket.DisposeAsync();
+    }
+}

--- a/LoxNetSharp/LoxoneHttpClient.cs
+++ b/LoxNetSharp/LoxoneHttpClient.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LoxNet;
+
+public class LoxoneHttpClient : IAsyncDisposable
+{
+    private readonly string _host;
+    private readonly int _port;
+    private readonly HttpClient _http;
+    private readonly bool _disposeHttpClient;
+    private readonly bool _secure;
+
+    public LoxoneHttpClient(HttpClient httpClient, string host, int port = 80, bool secure = false)
+    {
+        _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _host = host;
+        _port = port;
+        _secure = secure;
+        _disposeHttpClient = false;
+        if (_http.BaseAddress is null)
+            _http.BaseAddress = new Uri($"{(_secure ? "https" : "http")}://{_host}:{_port}");
+    }
+
+    public LoxoneHttpClient(HttpClient httpClient)
+    {
+        _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        if (_http.BaseAddress is null)
+            throw new ArgumentException("HttpClient must have BaseAddress set", nameof(httpClient));
+        _host = _http.BaseAddress.Host;
+        _port = _http.BaseAddress.Port;
+        _secure = _http.BaseAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase);
+        _disposeHttpClient = false;
+    }
+
+    public LoxoneHttpClient(string host, int port = 80, bool secure = false)
+        : this(new HttpClient(), host, port, secure)
+    {
+        _disposeHttpClient = true;
+    }
+
+    private string BaseUrl => _http.BaseAddress?.ToString().TrimEnd('/') ?? $"{(_secure ? "https" : "http")}://{_host}:{_port}";
+
+    private async Task<JsonDocument> RequestJsonAsync(string path)
+    {
+        using var resp = await _http.GetAsync($"{BaseUrl}/{path}");
+        resp.EnsureSuccessStatusCode();
+        var stream = await resp.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    public async Task<KeyInfo> GetKey2Async(string user)
+    {
+        using var doc = await RequestJsonAsync($"jdev/sys/getkey2/{Uri.EscapeDataString(user)}");
+        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return new KeyInfo(
+            value.GetProperty("key").GetString()!,
+            value.GetProperty("salt").GetString()!,
+            value.GetProperty("hashAlg").GetString()!
+        );
+    }
+
+    public async Task<string> GetKeyAsync()
+    {
+        using var doc = await RequestJsonAsync("jdev/sys/getkey");
+        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+    }
+
+    private static string HashToUpper(ReadOnlySpan<byte> data, HashAlgorithm algo)
+    {
+        var hash = algo.ComputeHash(data.ToArray());
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+            sb.Append(b.ToString("X2"));
+        return sb.ToString();
+    }
+
+    private static string HmacHex(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data, HashAlgorithmName name)
+    {
+        using HMAC hmac = name == HashAlgorithmName.SHA256
+            ? new HMACSHA256(key.ToArray())
+            : new HMACSHA1(key.ToArray());
+        var hash = hmac.ComputeHash(data.ToArray());
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+            sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+
+    public async Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info)
+    {
+        var keyInfo = await GetKey2Async(user);
+        var keyBytes = Convert.FromHexString(keyInfo.Key);
+        var algoName = keyInfo.HashAlg.Equals("sha256", StringComparison.OrdinalIgnoreCase) ? HashAlgorithmName.SHA256 : HashAlgorithmName.SHA1;
+        using HashAlgorithm algo = algoName == HashAlgorithmName.SHA256 ? SHA256.Create() : SHA1.Create();
+        var pwHash = HashToUpper(Encoding.UTF8.GetBytes($"{password}:{keyInfo.Salt}"), algo);
+        var userHash = HmacHex(keyBytes, Encoding.UTF8.GetBytes($"{user}:{pwHash}"), algoName);
+        var uid = Guid.NewGuid().ToString("N");
+        var encInfo = Uri.EscapeDataString(info);
+        using var doc = await RequestJsonAsync($"jdev/sys/getjwt/{userHash}/{user}/{permission}/{uid}/{encInfo}");
+        var val = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return new TokenInfo(
+            val.GetProperty("token").GetString()!,
+            val.GetProperty("validUntil").GetInt64(),
+            val.GetProperty("tokenRights").GetInt32(),
+            val.GetProperty("unsecurePass").GetBoolean(),
+            val.GetProperty("key").GetString()!
+        );
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposeHttpClient)
+            _http.Dispose();
+        await Task.CompletedTask;
+    }
+}
+

--- a/LoxNetSharp/Models.cs
+++ b/LoxNetSharp/Models.cs
@@ -1,0 +1,10 @@
+namespace LoxNet;
+
+using System.Text.Json;
+
+public record LoxoneMessage(int Code, JsonElement? Value, string? Message);
+
+public record KeyInfo(string Key, string Salt, string HashAlg);
+
+public record TokenInfo(string Token, long ValidUntil, int TokenRights, bool UnsecurePass, string Key);
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # LoxNet
-Loxone miniserver
+
+C# library for interacting with a Loxone Miniserver. The implementation follows the official communication specification.
+
+```csharp
+using LoxNet;
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddHttpClient();
+var provider = services.BuildServiceProvider();
+
+var client = new LoxoneClient("192.168.1.77", 443, secure: true);
+var jwt = await client.Http.GetJwtAsync("admin", "password", 4, "Example client");
+await client.WebSocket.ConnectAsync();
+await client.WebSocket.AuthenticateWithTokenAsync(jwt.Token, "admin");
+await client.WebSocket.KeepAliveAsync();
+await client.DisposeAsync();
+```
+
+For manual usage without DI:
+
+```csharp
+var client = new LoxoneClient("192.168.1.77", 443, secure: true);
+await client.WebSocket.ConnectAsync();
+// ...
+```


### PR DESCRIPTION
## Summary
- split `LoxoneClient` into `LoxoneHttpClient` and `LoxoneWebSocketClient`
- add new shared `Models` record types
- update README with example using the refactored client
- provide convenience wrapper `LoxoneClient`

## Testing
- `dotnet build LoxNetSharp/LoxNet.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6868112603a883268bc38ac9477a67eb