### PR TITLE
Add shared connection options and token caching

### DIFF
--- a/LoxNetSharp/ConnectionOptions.cs
+++ b/LoxNetSharp/ConnectionOptions.cs
@@ -1,0 +1,3 @@
+namespace LoxNet;
+
+public record LoxoneConnectionOptions(string Host, int Port = 80, bool Secure = false);

--- a/LoxNetSharp/LoxoneClient.cs
+++ b/LoxNetSharp/LoxoneClient.cs
@@ -8,16 +8,21 @@ public class LoxoneClient : IAsyncDisposable
     public LoxoneHttpClient Http { get; }
     public LoxoneWebSocketClient WebSocket { get; }
 
-    public LoxoneClient(string host, int port = 80, bool secure = false)
+    public LoxoneClient(LoxoneConnectionOptions options)
     {
-        Http = new LoxoneHttpClient(host, port, secure);
-        WebSocket = new LoxoneWebSocketClient(Http, host, port, secure);
+        Http = new LoxoneHttpClient(options);
+        WebSocket = new LoxoneWebSocketClient(Http);
     }
 
-    public LoxoneClient(LoxoneHttpClient httpClient, string host, int port = 80, bool secure = false)
+    public LoxoneClient(string host, int port = 80, bool secure = false)
+        : this(new LoxoneConnectionOptions(host, port, secure))
     {
-        Http = httpClient;
-        WebSocket = new LoxoneWebSocketClient(Http, host, port, secure);
+    }
+
+    public LoxoneClient(LoxoneHttpClient httpClient)
+    {
+        Http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        WebSocket = new LoxoneWebSocketClient(Http);
     }
 
     public async ValueTask DisposeAsync()

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ C# library for interacting with a Loxone Miniserver. The implementation follows 
 ```csharp
 using LoxNet;
 
-var client = new LoxoneClient("192.168.1.77", 443, secure: true);
+var options = new LoxoneConnectionOptions("192.168.1.77", 443, secure: true);
+var client = new LoxoneClient(options);
 var jwt = await client.Http.GetJwtAsync("admin", "password", 4, "Example client");
-await client.WebSocket.ConnectAsync();
-await client.WebSocket.AuthenticateWithTokenAsync(jwt.Token, "admin");
+await client.WebSocket.ConnectAndAuthenticateAsync("admin");
 await client.WebSocket.KeepAliveAsync();
 await client.WebSocket.CloseAsync();
 ```
@@ -16,8 +16,7 @@ await client.WebSocket.CloseAsync();
 For manual usage without DI:
 
 ```csharp
-var client = new LoxoneClient("192.168.1.77", 443, secure: true);
+var client = new LoxoneClient(new LoxoneConnectionOptions("192.168.1.77", 443, secure: true));
 var jwt = await client.Http.GetJwtAsync("admin", "password", 4, "Example client");
-await client.WebSocket.ConnectAsync();
-await client.WebSocket.AuthenticateWithTokenAsync(jwt.Token, "admin");
+await client.WebSocket.ConnectAndAuthenticateAsync("admin");
 ```


### PR DESCRIPTION
## Summary
- introduce `LoxoneConnectionOptions` for host/port/secure info
- cache JWT tokens in `LoxoneHttpClient` and expose via `LastToken`
- use cached token from `LoxoneWebSocketClient` with `ConnectAndAuthenticateAsync`
- add null checks when injecting clients
- update README with new usage

## Testing
- `dotnet build`
- `dotnet format --verify-no-changes -v diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6868c90730148326b1140dde26358b7f