### PR TITLE
Use PolySharp for net48 records

### DIFF
--- a/LoxNet.Client/HexUtils.cs
+++ b/LoxNet.Client/HexUtils.cs
@@ -1,0 +1,17 @@
+namespace LoxNet;
+
+internal static class HexUtils
+{
+#if NET48
+    public static byte[] FromHexString(string hex)
+    {
+        if (hex == null) throw new System.ArgumentNullException(nameof(hex));
+        var result = new byte[hex.Length / 2];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = System.Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        return result;
+    }
+#else
+    public static byte[] FromHexString(string hex) => System.Convert.FromHexString(hex);
+#endif
+}

--- a/LoxNet.Client/LoxNet.Client.csproj
+++ b/LoxNet.Client/LoxNet.Client.csproj
@@ -1,9 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;net6.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.6" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
+  </ItemGroup>
 
 </Project>

--- a/LoxNet.Client/LoxoneHttpClient.cs
+++ b/LoxNet.Client/LoxoneHttpClient.cs
@@ -86,7 +86,7 @@ public class LoxoneHttpClient : IAsyncDisposable
     public async Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info)
     {
         var keyInfo = await GetKey2Async(user);
-        var keyBytes = Convert.FromHexString(keyInfo.Key);
+        var keyBytes = HexUtils.FromHexString(keyInfo.Key);
         var algoName = keyInfo.HashAlg.Equals("sha256", StringComparison.OrdinalIgnoreCase) ? HashAlgorithmName.SHA256 : HashAlgorithmName.SHA1;
         using HashAlgorithm algo = algoName == HashAlgorithmName.SHA256 ? SHA256.Create() : SHA1.Create();
         var pwHash = HashToUpper(Encoding.UTF8.GetBytes($"{password}:{keyInfo.Salt}"), algo);
@@ -110,6 +110,10 @@ public class LoxoneHttpClient : IAsyncDisposable
     {
         if (_disposeHttpClient)
             _http.Dispose();
+#if NET48
+        return default;
+#else
         return ValueTask.CompletedTask;
+#endif
     }
 }

--- a/LoxNet.Client/LoxoneWebSocketClient.cs
+++ b/LoxNet.Client/LoxoneWebSocketClient.cs
@@ -72,7 +72,7 @@ public class LoxoneWebSocketClient : IAsyncDisposable
     public async Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user)
     {
         using var doc = await _http.RequestJsonAsync("jdev/sys/getkey");
-        var key = Convert.FromHexString(doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!);
+        var key = HexUtils.FromHexString(doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!);
         var digest = LoxoneHttpClient.HmacHex(key, Encoding.UTF8.GetBytes(token), System.Security.Cryptography.HashAlgorithmName.SHA1);
         return await SendCommandAsync($"authwithtoken/{digest}/{user}");
     }


### PR DESCRIPTION
## Summary
- remove obsolete `IsExternalInit` stub
- pull in PolySharp package on net48 to supply polyfills

## Testing
- `dotnet build LoxNet.Client/LoxNet.Client.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6868d92291d08326825fc2507fe458f7