### PR TITLE
Add Loxone room and category records

### DIFF
--- a/LoxNet.Client/LoxoneStructureCache.cs
+++ b/LoxNet.Client/LoxoneStructureCache.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LoxNet;
+
+public class LoxoneControl
+{
+    public string Uuid { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Type { get; init; } = "";
+    public string? RoomId { get; init; }
+    public string? CategoryId { get; init; }
+    public string? RoomName { get; init; }
+    public string? CategoryName { get; init; }
+}
+
+public class LoxoneStructureCache
+{
+    private readonly LoxoneHttpClient _httpClient;
+    private readonly Dictionary<string, LoxoneControl> _uuidMap = new();
+    private readonly Dictionary<string, LoxoneRoom> _roomMap = new();
+    private readonly Dictionary<string, LoxoneCategory> _categoryMap = new();
+
+    public LoxoneStructureCache(LoxoneHttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    public IReadOnlyDictionary<string, LoxoneControl> Controls => _uuidMap;
+    public IReadOnlyDictionary<string, LoxoneRoom> Rooms => _roomMap;
+    public IReadOnlyDictionary<string, LoxoneCategory> Categories => _categoryMap;
+
+    public async Task LoadAsync()
+    {
+        using var doc = await _httpClient.RequestJsonAsync("data/LoxApp3.json");
+
+        _uuidMap.Clear();
+        _roomMap.Clear();
+        _categoryMap.Clear();
+
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("rooms", out var rooms))
+        {
+            foreach (var roomProp in rooms.EnumerateObject())
+            {
+                var id = roomProp.Name;
+                var name = roomProp.Value.GetProperty("name").GetString() ?? id;
+                _roomMap[id] = new LoxoneRoom(id, name);
+            }
+        }
+
+        if (root.TryGetProperty("cats", out var cats))
+        {
+            foreach (var catProp in cats.EnumerateObject())
+            {
+                var id = catProp.Name;
+                var name = catProp.Value.GetProperty("name").GetString() ?? id;
+                _categoryMap[id] = new LoxoneCategory(id, name);
+            }
+        }
+
+        if (root.TryGetProperty("controls", out var controls))
+        {
+            foreach (var controlProp in controls.EnumerateObject())
+            {
+                var uuid = controlProp.Name;
+                var obj = controlProp.Value;
+
+                var roomId = obj.TryGetProperty("room", out var roomVal) ? roomVal.GetString() : null;
+                var catId = obj.TryGetProperty("cat", out var catVal) ? catVal.GetString() : null;
+
+                var control = new LoxoneControl
+                {
+                    Uuid = uuid,
+                    Name = obj.GetProperty("name").GetString() ?? uuid,
+                    Type = obj.GetProperty("type").GetString() ?? string.Empty,
+                    RoomId = roomId,
+                    CategoryId = catId,
+                    RoomName = roomId != null && _roomMap.TryGetValue(roomId, out var room) ? room.Name : null,
+                    CategoryName = catId != null && _categoryMap.TryGetValue(catId, out var cat) ? cat.Name : null
+                };
+
+                _uuidMap[uuid] = control;
+
+                if (obj.TryGetProperty("uuidAction", out var uuidAction) &&
+                    uuidAction.GetString() is { } actionUuid && actionUuid != uuid)
+                {
+                    _uuidMap[actionUuid] = control;
+                }
+
+                if (obj.TryGetProperty("states", out var states))
+                {
+                    foreach (var stateProp in states.EnumerateObject())
+                    {
+                        var stateUuid = stateProp.Value.GetString();
+                        if (!string.IsNullOrWhiteSpace(stateUuid))
+                        {
+                            _uuidMap[stateUuid] = control;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public bool TryGetControl(string uuid, out LoxoneControl? control) =>
+        _uuidMap.TryGetValue(uuid, out control);
+
+    public bool TryGetControlByName(string name, out LoxoneControl? control)
+    {
+        control = _uuidMap.Values.FirstOrDefault(c =>
+            string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+        return control is not null;
+    }
+
+    public IEnumerable<LoxoneControl> GetControlsByRoom(string roomName)
+    {
+        return _uuidMap.Values
+            .Where(c => string.Equals(c.RoomName, roomName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public IEnumerable<LoxoneControl> GetControlsByCategory(string categoryName)
+    {
+        return _uuidMap.Values
+            .Where(c => string.Equals(c.CategoryName, categoryName, StringComparison.OrdinalIgnoreCase));
+    }
+}
+

--- a/LoxNet.Client/Models.cs
+++ b/LoxNet.Client/Models.cs
@@ -7,3 +7,7 @@ public record LoxoneMessage(int Code, JsonElement? Value, string? Message);
 public record KeyInfo(string Key, string Salt, string HashAlg);
 
 public record TokenInfo(string Token, long ValidUntil, int TokenRights, bool UnsecurePass, string Key);
+
+public record LoxoneRoom(string Id, string Name);
+
+public record LoxoneCategory(string Id, string Name);

--- a/README.md
+++ b/README.md
@@ -20,3 +20,22 @@ var client = new LoxoneClient(new LoxoneConnectionOptions("192.168.1.77", 443, s
 var jwt = await client.Http.GetJwtAsync("admin", "password", 4, "Example client");
 await client.WebSocket.ConnectAndAuthenticateAsync("admin");
 ```
+
+## Structure Cache
+
+Load the structure and query controls by name, room or category:
+
+```csharp
+var cache = new LoxoneStructureCache(client.Http);
+await cache.LoadAsync();
+
+if (cache.TryGetControlByName("Kitchen Temp", out var ctrl))
+    Console.WriteLine($"UUID: {ctrl.Uuid}, Type: {ctrl.Type}");
+
+foreach (var c in cache.GetControlsByRoom("Bathroom"))
+    Console.WriteLine($"{c.Name} ({c.Type})");
+
+foreach (var c in cache.GetControlsByCategory("Lighting"))
+    Console.WriteLine($"{c.Name} ({c.Uuid})");
+```
+


### PR DESCRIPTION
## Summary
- define `LoxoneRoom` and `LoxoneCategory` records
- store rooms and categories as those records in `LoxoneStructureCache`

## Testing
- `dotnet build LoxNet.Client/LoxNet.Client.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6868fd99d20c8326996337aa844d8782