### PR TITLE
Add interfaces and tests

### DIFF
--- a/LoxNet.Client/Interfaces/ILoxoneClient.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneClient.cs
@@ -1,0 +1,7 @@
+namespace LoxNet;
+
+public interface ILoxoneClient : IAsyncDisposable
+{
+    ILoxoneHttpClient Http { get; }
+    ILoxoneWebSocketClient WebSocket { get; }
+}

--- a/LoxNet.Client/Interfaces/ILoxoneHttpClient.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneHttpClient.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LoxNet;
+
+public interface ILoxoneHttpClient : IAsyncDisposable
+{
+    LoxoneConnectionOptions Options { get; }
+    TokenInfo? LastToken { get; }
+    Task<JsonDocument> RequestJsonAsync(string path);
+    Task<KeyInfo> GetKey2Async(string user);
+    Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info);
+}

--- a/LoxNet.Client/Interfaces/ILoxoneStructureCache.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneStructureCache.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LoxNet;
+
+public interface ILoxoneStructureCache
+{
+    IReadOnlyDictionary<string, LoxoneControl> Controls { get; }
+    IReadOnlyDictionary<string, LoxoneRoom> Rooms { get; }
+    IReadOnlyDictionary<string, LoxoneCategory> Categories { get; }
+
+    Task LoadAsync();
+    bool TryGetControl(string uuid, out LoxoneControl? control);
+    bool TryGetControlByName(string name, out LoxoneControl? control);
+    IEnumerable<LoxoneControl> GetControlsByRoom(string roomName);
+    IEnumerable<LoxoneControl> GetControlsByCategory(string categoryName);
+}

--- a/LoxNet.Client/Interfaces/ILoxoneWebSocketClient.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneWebSocketClient.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+
+namespace LoxNet;
+
+public interface ILoxoneWebSocketClient : IAsyncDisposable
+{
+    Task ConnectAsync();
+    Task CloseAsync();
+    Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user);
+    Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user);
+    Task KeepAliveAsync();
+    Task<LoxoneMessage> CommandAsync(string path);
+}

--- a/LoxNet.Client/LoxoneClient.cs
+++ b/LoxNet.Client/LoxoneClient.cs
@@ -3,10 +3,10 @@ using System.Threading.Tasks;
 
 namespace LoxNet;
 
-public class LoxoneClient : IAsyncDisposable
+public class LoxoneClient : ILoxoneClient
 {
-    public LoxoneHttpClient Http { get; }
-    public LoxoneWebSocketClient WebSocket { get; }
+    public ILoxoneHttpClient Http { get; }
+    public ILoxoneWebSocketClient WebSocket { get; }
 
     public LoxoneClient(LoxoneConnectionOptions options)
     {
@@ -19,7 +19,7 @@ public class LoxoneClient : IAsyncDisposable
     {
     }
 
-    public LoxoneClient(LoxoneHttpClient httpClient)
+    public LoxoneClient(ILoxoneHttpClient httpClient)
     {
         Http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         WebSocket = new LoxoneWebSocketClient(Http);

--- a/LoxNet.Client/LoxoneHttpClient.cs
+++ b/LoxNet.Client/LoxoneHttpClient.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace LoxNet;
 
-public class LoxoneHttpClient : IAsyncDisposable
+public class LoxoneHttpClient : ILoxoneHttpClient
 {
     private readonly HttpClient _http;
     private readonly bool _disposeHttpClient;
@@ -43,7 +43,7 @@ public class LoxoneHttpClient : IAsyncDisposable
 
     private string BaseUrl => _http.BaseAddress?.ToString().TrimEnd('/') ?? $"{(Options.Secure ? "https" : "http")}://{Options.Host}:{Options.Port}";
 
-    internal async Task<JsonDocument> RequestJsonAsync(string path)
+    public async Task<JsonDocument> RequestJsonAsync(string path)
     {
         using var resp = await _http.GetAsync($"{BaseUrl}/{path}");
         resp.EnsureSuccessStatusCode();

--- a/LoxNet.Client/LoxoneStructureCache.cs
+++ b/LoxNet.Client/LoxoneStructureCache.cs
@@ -17,14 +17,14 @@ public class LoxoneControl
     public string? CategoryName { get; init; }
 }
 
-public class LoxoneStructureCache
+public class LoxoneStructureCache : ILoxoneStructureCache
 {
-    private readonly LoxoneHttpClient _httpClient;
+    private readonly ILoxoneHttpClient _httpClient;
     private readonly Dictionary<string, LoxoneControl> _uuidMap = new();
     private readonly Dictionary<string, LoxoneRoom> _roomMap = new();
     private readonly Dictionary<string, LoxoneCategory> _categoryMap = new();
 
-    public LoxoneStructureCache(LoxoneHttpClient httpClient)
+    public LoxoneStructureCache(ILoxoneHttpClient httpClient)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }

--- a/LoxNet.Client/LoxoneWebSocketClient.cs
+++ b/LoxNet.Client/LoxoneWebSocketClient.cs
@@ -7,12 +7,12 @@ using System.Threading.Tasks;
 
 namespace LoxNet;
 
-public class LoxoneWebSocketClient : IAsyncDisposable
+public class LoxoneWebSocketClient : ILoxoneWebSocketClient
 {
-    private readonly LoxoneHttpClient _http;
+    private readonly ILoxoneHttpClient _http;
     private ClientWebSocket? _ws;
 
-    public LoxoneWebSocketClient(LoxoneHttpClient httpClient)
+    public LoxoneWebSocketClient(ILoxoneHttpClient httpClient)
     {
         _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }

--- a/LoxNet.Tests/ConfigParsingTests.cs
+++ b/LoxNet.Tests/ConfigParsingTests.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace LoxNet.Tests;
+
+public class ConfigParsingTests
+{
+    [Fact]
+    public void ParseDemoConfig_ContainsRoomsCategoriesAndControls()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Demo Case Config UK.Loxone");
+        var doc = XDocument.Load(path);
+
+        var categories = doc.Descendants("C")
+            .Where(e => (string?)e.Attribute("Type") == "Category")
+            .Select(e => (string?)e.Attribute("Title"))
+            .ToList();
+        Assert.Contains("Lighting", categories);
+
+        var rooms = doc.Descendants("C")
+            .Where(e => (string?)e.Attribute("Type") == "Place")
+            .Select(e => (string?)e.Attribute("Title"))
+            .ToList();
+        Assert.Contains("Kitchen", rooms);
+
+        var controls = doc.Descendants("C")
+            .Where(e => e.Attribute("U") != null)
+            .Where(e => (string?)e.Attribute("Type") != "Category" && (string?)e.Attribute("Type") != "Place")
+            .Select(e => (string?)e.Attribute("Title"))
+            .ToList();
+        Assert.Contains("Lighting controller", controls);
+    }
+}

--- a/LoxNet.Tests/LoxNet.Tests.csproj
+++ b/LoxNet.Tests/LoxNet.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Demo Case Config UK.Loxone">
+      <Link>Demo Case Config UK.Loxone</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LoxNet.Client\LoxNet.Client.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add interfaces for HTTP client, websocket client, structure cache and aggregate client
- update implementations to use the new abstractions
- include demo config in test project
- add a unit test verifying demo configuration parsing

## Testing
- `dotnet test LoxNet.Tests/LoxNet.Tests.csproj -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68693cbf52708326922a620c71dacf44