### PR TITLE
Add optional control properties

### DIFF
--- a/LoxNet.Client/Controls/LightController.cs
+++ b/LoxNet.Client/Controls/LightController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LoxNet;
@@ -7,10 +8,24 @@ namespace LoxNet;
 /// </summary>
 public class LightController : LoxoneControl
 {
+    private LightControllerDetails? _details;
+
     /// <summary>
     /// Additional data parsed from the <c>details</c> section of the structure file.
     /// </summary>
-    public LightControllerDetails? Details { get; set; }
+    public LightControllerDetails? Details
+    {
+        get
+        {
+            if (_details == null && RawDetails.HasValue)
+            {
+                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                _details = JsonSerializer.Deserialize<LightControllerDetails>(RawDetails.Value.GetRawText(), opts);
+            }
+            return _details;
+        }
+        set => _details = value;
+    }
 
     /// <summary>
     /// UUID of the state representing the currently active scene.

--- a/LoxNet.Client/Controls/LightController.cs
+++ b/LoxNet.Client/Controls/LightController.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LoxNet;
@@ -6,26 +5,8 @@ namespace LoxNet;
 /// <summary>
 /// Provides methods specific to the <c>LightController</c> type.
 /// </summary>
-public class LightController : LoxoneControl
+public class LightController : LoxoneControl<LightControllerDetails>
 {
-    private LightControllerDetails? _details;
-
-    /// <summary>
-    /// Additional data parsed from the <c>details</c> section of the structure file.
-    /// </summary>
-    public LightControllerDetails? Details
-    {
-        get
-        {
-            if (_details == null && RawDetails.HasValue)
-            {
-                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                _details = JsonSerializer.Deserialize<LightControllerDetails>(RawDetails.Value.GetRawText(), opts);
-            }
-            return _details;
-        }
-        set => _details = value;
-    }
 
     /// <summary>
     /// UUID of the state representing the currently active scene.

--- a/LoxNet.Client/Controls/LightControllerV2.cs
+++ b/LoxNet.Client/Controls/LightControllerV2.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
@@ -9,10 +10,24 @@ namespace LoxNet;
 /// </summary>
 public class LightControllerV2 : LoxoneControl
 {
+    private LightControllerV2Details? _details;
+
     /// <summary>
     /// Additional data parsed from the <c>details</c> section of the structure file.
     /// </summary>
-    public LightControllerV2Details? Details { get; set; }
+    public LightControllerV2Details? Details
+    {
+        get
+        {
+            if (_details == null && RawDetails.HasValue)
+            {
+                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                _details = JsonSerializer.Deserialize<LightControllerV2Details>(RawDetails.Value.GetRawText(), opts);
+            }
+            return _details;
+        }
+        set => _details = value;
+    }
 
     /// <summary>
     /// UUID of the state listing the active moods.

--- a/LoxNet.Client/Controls/LightControllerV2.cs
+++ b/LoxNet.Client/Controls/LightControllerV2.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
@@ -8,26 +7,8 @@ namespace LoxNet;
 /// <summary>
 /// Provides commands for the LightControllerV2 control.
 /// </summary>
-public class LightControllerV2 : LoxoneControl
+public class LightControllerV2 : LoxoneControl<LightControllerV2Details>
 {
-    private LightControllerV2Details? _details;
-
-    /// <summary>
-    /// Additional data parsed from the <c>details</c> section of the structure file.
-    /// </summary>
-    public LightControllerV2Details? Details
-    {
-        get
-        {
-            if (_details == null && RawDetails.HasValue)
-            {
-                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                _details = JsonSerializer.Deserialize<LightControllerV2Details>(RawDetails.Value.GetRawText(), opts);
-            }
-            return _details;
-        }
-        set => _details = value;
-    }
 
     /// <summary>
     /// UUID of the state listing the active moods.

--- a/LoxNet.Client/Controls/LoxoneControlFactory.cs
+++ b/LoxNet.Client/Controls/LoxoneControlFactory.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace LoxNet;
 
 /// <summary>
@@ -18,36 +16,4 @@ public static class LoxoneControlFactory
         _ => new LoxoneControl()
     };
 
-    /// <summary>
-    /// Populates control specific detail properties using the raw details from
-    /// <see cref="LoxoneControl.RawDetails"/>.
-    /// </summary>
-    /// <param name="control">The control instance whose details should be parsed.</param>
-    /// <param name="options">Serializer options for deserializing the details.</param>
-    public static void ParseDetails(LoxoneControl control, JsonSerializerOptions options)
-    {
-        var details = control.RawDetails;
-        if (!details.HasValue)
-            return;
-
-        switch (control)
-        {
-            case LightController light:
-                light.Details = DeserializeDetails<LightControllerDetails>(details, options);
-                break;
-            case LightControllerV2 lightV2:
-                lightV2.Details = DeserializeDetails<LightControllerV2Details>(details, options);
-                break;
-            case SwitchControl sw:
-                sw.Details = DeserializeDetails<SwitchControlDetails>(details, options);
-                break;
-        }
-    }
-
-    private static T? DeserializeDetails<T>(JsonElement? details, JsonSerializerOptions options)
-    {
-        return details.HasValue
-            ? JsonSerializer.Deserialize<T>(details.Value.GetRawText(), options)
-            : default;
-    }
 }

--- a/LoxNet.Client/Controls/LoxoneControlFactory.cs
+++ b/LoxNet.Client/Controls/LoxoneControlFactory.cs
@@ -10,44 +10,38 @@ public static class LoxoneControlFactory
     /// <summary>
     /// Creates a control instance for the given type.
     /// </summary>
-    public static LoxoneControl Create(ControlType type)
+    public static LoxoneControl Create(ControlType type) => type switch
     {
-        return type switch
-        {
-            ControlType.Switch => new SwitchControl(),
-            ControlType.LightController => new LightController(),
-            ControlType.LightControllerV2 => new LightControllerV2(),
-            _ => new LoxoneControl()
-        };
-    }
+        ControlType.Switch => new SwitchControl(),
+        ControlType.LightController => new LightController(),
+        ControlType.LightControllerV2 => new LightControllerV2(),
+        _ => new LoxoneControl()
+    };
 
     /// <summary>
-    /// Creates a typed control and populates detail properties when present.
+    /// Populates control specific detail properties using the raw details from
+    /// <see cref="LoxoneControl.RawDetails"/>.
     /// </summary>
-    /// <param name="type">The control type to instantiate.</param>
-    /// <param name="details">Optional details JSON element from the structure file.</param>
+    /// <param name="control">The control instance whose details should be parsed.</param>
     /// <param name="options">Serializer options for deserializing the details.</param>
-    public static LoxoneControl Create(ControlType type, JsonElement? details, JsonSerializerOptions options)
+    public static void ParseDetails(LoxoneControl control, JsonSerializerOptions options)
     {
-        var ctrl = Create(type);
+        var details = control.RawDetails;
+        if (!details.HasValue)
+            return;
 
-        if (details.HasValue)
+        switch (control)
         {
-            switch (ctrl)
-            {
-                case LightController light:
-                    light.Details = DeserializeDetails<LightControllerDetails>(details, options);
-                    break;
-                case LightControllerV2 lightV2:
-                    lightV2.Details = DeserializeDetails<LightControllerV2Details>(details, options);
-                    break;
-                case SwitchControl sw:
-                    sw.Details = DeserializeDetails<SwitchControlDetails>(details, options);
-                    break;
-            }
+            case LightController light:
+                light.Details = DeserializeDetails<LightControllerDetails>(details, options);
+                break;
+            case LightControllerV2 lightV2:
+                lightV2.Details = DeserializeDetails<LightControllerV2Details>(details, options);
+                break;
+            case SwitchControl sw:
+                sw.Details = DeserializeDetails<SwitchControlDetails>(details, options);
+                break;
         }
-
-        return ctrl;
     }
 
     private static T? DeserializeDetails<T>(JsonElement? details, JsonSerializerOptions options)

--- a/LoxNet.Client/Controls/SwitchControl.cs
+++ b/LoxNet.Client/Controls/SwitchControl.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LoxNet;
@@ -7,10 +8,24 @@ namespace LoxNet;
 /// </summary>
 public class SwitchControl : LoxoneControl
 {
+    private SwitchControlDetails? _details;
+
     /// <summary>
     /// Additional detail information for this switch control.
     /// </summary>
-    public SwitchControlDetails? Details { get; set; }
+    public SwitchControlDetails? Details
+    {
+        get
+        {
+            if (_details == null && RawDetails.HasValue)
+            {
+                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                _details = JsonSerializer.Deserialize<SwitchControlDetails>(RawDetails.Value.GetRawText(), opts);
+            }
+            return _details;
+        }
+        set => _details = value;
+    }
 
     /// <summary>
     /// UUID of the "active" state for this switch.

--- a/LoxNet.Client/Controls/SwitchControl.cs
+++ b/LoxNet.Client/Controls/SwitchControl.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LoxNet;
@@ -6,26 +5,8 @@ namespace LoxNet;
 /// <summary>
 /// Provides convenience methods for the <c>Switch</c> control.
 /// </summary>
-public class SwitchControl : LoxoneControl
+public class SwitchControl : LoxoneControl<SwitchControlDetails>
 {
-    private SwitchControlDetails? _details;
-
-    /// <summary>
-    /// Additional detail information for this switch control.
-    /// </summary>
-    public SwitchControlDetails? Details
-    {
-        get
-        {
-            if (_details == null && RawDetails.HasValue)
-            {
-                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                _details = JsonSerializer.Deserialize<SwitchControlDetails>(RawDetails.Value.GetRawText(), opts);
-            }
-            return _details;
-        }
-        set => _details = value;
-    }
 
     /// <summary>
     /// UUID of the "active" state for this switch.

--- a/LoxNet.Client/LoxoneStructureState.cs
+++ b/LoxNet.Client/LoxoneStructureState.cs
@@ -84,7 +84,7 @@ public class LoxoneStructureState : ILoxoneStructureState
         }
     }
 
-    private void AddControl(string uuid, ControlDto dto, string? parentRoomId, string? parentCatId, JsonSerializerOptions options)
+    private void AddControl(string uuid, ControlDto dto, string? parentRoomId, string? parentCatId, JsonSerializerOptions options, LoxoneControl? host = null)
     {
         var roomId = dto.Room ?? parentRoomId;
         var catId = dto.Category ?? parentCatId;
@@ -132,18 +132,30 @@ public class LoxoneStructureState : ILoxoneStructureState
             }
         }
 
-        _uuidMap[uuid] = control;
-
-        if (control.UuidAction is { } actionUuid && actionUuid != uuid)
+        if (host == null)
         {
-            _uuidMap[actionUuid] = control;
+            _uuidMap[uuid] = control;
+
+            if (control.UuidAction is { } actionUuid && actionUuid != uuid)
+            {
+                _uuidMap[actionUuid] = control;
+            }
+        }
+        else
+        {
+            host.SubControls[uuid] = control;
+
+            if (control.UuidAction is { } actionUuid)
+            {
+                _uuidMap[actionUuid] = control;
+            }
         }
 
         if (dto.SubControls is { } subs)
         {
             foreach (var sub in subs)
             {
-                AddControl(sub.Key, sub.Value, roomId, catId, options);
+                AddControl(sub.Key, sub.Value, roomId, catId, options, control);
             }
         }
     }

--- a/LoxNet.Client/LoxoneStructureState.cs
+++ b/LoxNet.Client/LoxoneStructureState.cs
@@ -117,10 +117,6 @@ public class LoxoneStructureState : ILoxoneStructureState
         control.SecuredDetails = dto.SecuredDetails;
         control.UuidAction = dto.UuidAction;
         control.RawDetails = dto.Details;
-        if (!_lightMode)
-        {
-            LoxoneControlFactory.ParseDetails(control, options);
-        }
         control.Statistic = dto.Statistic;
         control.Restrictions = dto.Restrictions;
         control.HasControlNotes = dto.HasControlNotes;

--- a/LoxNet.Client/LoxoneStructureState.cs
+++ b/LoxNet.Client/LoxoneStructureState.cs
@@ -103,7 +103,7 @@ public class LoxoneStructureState : ILoxoneStructureState
 
         var control = _lightMode
             ? new LoxoneControl()
-            : LoxoneControlFactory.Create(ctrlType, dto.Details, options);
+            : LoxoneControlFactory.Create(ctrlType);
 
         control.Uuid = uuid;
         control.Name = name;
@@ -114,7 +114,18 @@ public class LoxoneStructureState : ILoxoneStructureState
         control.CategoryName = categoryName;
         control.DefaultRating = dto.DefaultRating;
         control.IsSecured = dto.IsSecured;
+        control.SecuredDetails = dto.SecuredDetails;
         control.UuidAction = dto.UuidAction;
+        control.RawDetails = dto.Details;
+        if (!_lightMode)
+        {
+            LoxoneControlFactory.ParseDetails(control, options);
+        }
+        control.Statistic = dto.Statistic;
+        control.Restrictions = dto.Restrictions;
+        control.HasControlNotes = dto.HasControlNotes;
+        control.Preset = dto.Preset is { } p ? new LoxonePreset(p.Uuid, p.Name) : null;
+        control.Links = dto.Links;
         control.States = dto.States;
 
         if (dto.States is not null)

--- a/LoxNet.Client/Models/LoxoneControl.Generic.cs
+++ b/LoxNet.Client/Models/LoxoneControl.Generic.cs
@@ -1,0 +1,28 @@
+namespace LoxNet;
+
+using System.Text.Json;
+
+/// <summary>
+/// Base representation for controls with typed detail information.
+/// </summary>
+public class LoxoneControl<TDetails> : LoxoneControl
+{
+    private TDetails? _details;
+
+    /// <summary>
+    /// Additional data parsed from <see cref="LoxoneControl.RawDetails"/> on first access.
+    /// </summary>
+    public TDetails? Details
+    {
+        get
+        {
+            if (_details == null && RawDetails.HasValue)
+            {
+                var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                _details = JsonSerializer.Deserialize<TDetails>(RawDetails.Value.GetRawText(), opts);
+            }
+            return _details;
+        }
+        set => _details = value;
+    }
+}

--- a/LoxNet.Client/Models/LoxoneControl.cs
+++ b/LoxNet.Client/Models/LoxoneControl.cs
@@ -74,6 +74,11 @@ public class LoxoneControl
     [JsonPropertyName("links")]
     public IReadOnlyList<string>? Links { get; set; }
 
+    /// <summary>
+    /// Collection of sub controls belonging to this control.
+    /// </summary>
+    public Dictionary<string, LoxoneControl> SubControls { get; } = new();
+
     /// <summary>Mapping of state names to UUIDs.</summary>
     [JsonPropertyName("states")]
     public IReadOnlyDictionary<string, string>? States { get; set; }

--- a/LoxNet.Client/Models/LoxoneControl.cs
+++ b/LoxNet.Client/Models/LoxoneControl.cs
@@ -42,9 +42,37 @@ public class LoxoneControl
     [JsonPropertyName("isSecured")]
     public bool? IsSecured { get; set; }
 
+    /// <summary>Flag indicating the control contains sensitive information.</summary>
+    [JsonPropertyName("securedDetails")]
+    public bool? SecuredDetails { get; set; }
+
     /// <summary>UUID used when sending commands to the control.</summary>
     [JsonPropertyName("uuidAction")]
     public string? UuidAction { get; set; }
+
+    /// <summary>Unparsed details element from the structure file.</summary>
+    [JsonPropertyName("details")]
+    public JsonElement? RawDetails { get; set; }
+
+    /// <summary>Statistic configuration for this control.</summary>
+    [JsonPropertyName("statistic")]
+    public JsonElement? Statistic { get; set; }
+
+    /// <summary>Restriction flags for this control.</summary>
+    [JsonPropertyName("restrictions")]
+    public int? Restrictions { get; set; }
+
+    /// <summary>Indicates if notes are available for this control.</summary>
+    [JsonPropertyName("hasControlNotes")]
+    public bool? HasControlNotes { get; set; }
+
+    /// <summary>Preset information if the control uses one.</summary>
+    [JsonPropertyName("preset")]
+    public LoxonePreset? Preset { get; set; }
+
+    /// <summary>UUIDs of linked controls.</summary>
+    [JsonPropertyName("links")]
+    public IReadOnlyList<string>? Links { get; set; }
 
     /// <summary>Mapping of state names to UUIDs.</summary>
     [JsonPropertyName("states")]

--- a/LoxNet.Client/Models/LoxonePreset.cs
+++ b/LoxNet.Client/Models/LoxonePreset.cs
@@ -1,0 +1,10 @@
+namespace LoxNet;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Preset information linked to a control.
+/// </summary>
+public record LoxonePreset(
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("name")] string? Name);

--- a/LoxNet.Client/Models/Structure/StructureDtos.cs
+++ b/LoxNet.Client/Models/Structure/StructureDtos.cs
@@ -48,15 +48,37 @@ internal class ControlDto
     [JsonPropertyName("isSecured")]
     public bool? IsSecured { get; set; }
 
+    [JsonPropertyName("securedDetails")]
+    public bool? SecuredDetails { get; set; }
+
     [JsonPropertyName("states")]
     public Dictionary<string, string>? States { get; set; }
 
     [JsonPropertyName("details")]
     public JsonElement? Details { get; set; }
 
+    [JsonPropertyName("statistic")]
+    public JsonElement? Statistic { get; set; }
+
+    [JsonPropertyName("restrictions")]
+    public int? Restrictions { get; set; }
+
+    [JsonPropertyName("hasControlNotes")]
+    public bool? HasControlNotes { get; set; }
+
+    [JsonPropertyName("preset")]
+    public PresetDto? Preset { get; set; }
+
+    [JsonPropertyName("links")]
+    public List<string>? Links { get; set; }
+
     [JsonPropertyName("subControls")]
     public Dictionary<string, ControlDto>? SubControls { get; set; }
 }
+
+internal record PresetDto(
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("name")] string? Name);
 
 /// <summary>
 /// Model for a room entry from the structure file.

--- a/LoxNet.Tests/StructureCacheTests.cs
+++ b/LoxNet.Tests/StructureCacheTests.cs
@@ -17,6 +17,12 @@ public class StructureCacheTests
       "uuidAction": "act-uuid-1",
       "defaultRating": 2,
       "isSecured": false,
+      "securedDetails": true,
+      "statistic": { "frequency": 1 },
+      "restrictions": 16,
+      "hasControlNotes": true,
+      "preset": { "uuid": "preset-uuid", "name": "Default" },
+      "links": ["link-1"],
       "room": "room-1",
       "cat": "cat-1",
       "states": { "active": "uuid-1-state" },
@@ -92,6 +98,13 @@ public class StructureCacheTests
         Assert.Equal("uuid-1-state", sw.ActiveState);
         Assert.Equal(2, ctrl.DefaultRating);
         Assert.False(ctrl.IsSecured);
+        Assert.True(ctrl.SecuredDetails);
+        Assert.True(ctrl.RawDetails.HasValue);
+        Assert.True(ctrl.Statistic.HasValue);
+        Assert.Equal(16, ctrl.Restrictions);
+        Assert.True(ctrl.HasControlNotes);
+        Assert.Equal("preset-uuid", ctrl.Preset!.Uuid);
+        Assert.Contains("link-1", ctrl.Links!);
         Assert.True(cache.TryGetControl("sub-uuid1", out var sub));
         Assert.IsType<SwitchControl>(sub);
         Assert.Equal("Sub Switch", sub!.Name);

--- a/LoxNet.Tests/StructureCacheTests.cs
+++ b/LoxNet.Tests/StructureCacheTests.cs
@@ -105,9 +105,9 @@ public class StructureCacheTests
         Assert.True(ctrl.HasControlNotes);
         Assert.Equal("preset-uuid", ctrl.Preset!.Uuid);
         Assert.Contains("link-1", ctrl.Links!);
-        Assert.True(cache.TryGetControl("sub-uuid1", out var sub));
-        Assert.IsType<SwitchControl>(sub);
-        Assert.Equal("Sub Switch", sub!.Name);
+        Assert.True(ctrl.SubControls.ContainsKey("sub-uuid1"));
+        var sub = Assert.IsType<SwitchControl>(ctrl.SubControls["sub-uuid1"]);
+        Assert.Equal("Sub Switch", sub.Name);
         Assert.Equal(ControlType.Switch, sub.Type);
 
         var room = cache.Rooms["room-1"];


### PR DESCRIPTION
## Summary
- support extra optional fields from Loxone structure file
- parse preset information and expose additional properties
- test optional field parsing
- parse control details using RawDetails property

## Testing
- `dotnet test LoxNet.Tests/LoxNet.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686a6f7863808326be53835c575401b9