### PR TITLE
Add calendar mode parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - The implementation follows the Loxone communication documentation. See:
   - <https://www.loxone.com/wp-content/uploads/datasheets/CommunicatingWithMiniserver.pdf>
   - <https://www.loxone.com/wp-content/uploads/datasheets/StructureFile.pdf>
+  - <https://www.loxone.com/wp-content/uploads/datasheets/OperatingModeSchedule.pdf>
 - To run the unit tests use the .NET SDK (9.0 or later):
   ```sh
   dotnet test LoxNet.Tests/LoxNet.Tests.csproj

--- a/LoxNet.Client/Interfaces/ILoxoneStructureState.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneStructureState.cs
@@ -32,6 +32,9 @@ public interface ILoxoneStructureState
     /// <summary>Returns all controls belonging to the specified category.</summary>
     IEnumerable<LoxoneControl> GetControlsByCategory(string categoryName);
 
+    /// <summary>Returns the available operating modes keyed by mode id.</summary>
+    IReadOnlyDictionary<int, string> GetOperatingModes();
+
     /// <summary>
     /// Attaches a WebSocket client to receive live state updates.
     /// </summary>

--- a/LoxNet.Client/LoxoneStructureState.cs
+++ b/LoxNet.Client/LoxoneStructureState.cs
@@ -12,6 +12,7 @@ public class LoxoneStructureState : ILoxoneStructureState
     private readonly Dictionary<string, LoxoneControl> _uuidMap = new();
     private readonly Dictionary<string, LoxoneRoom> _roomMap = new();
     private readonly Dictionary<string, LoxoneCategory> _categoryMap = new();
+    private readonly Dictionary<int, string> _operatingModes = new();
     private readonly bool _lightMode;
     private ILoxoneWebSocketClient? _wsClient;
 
@@ -43,6 +44,7 @@ public class LoxoneStructureState : ILoxoneStructureState
     public IReadOnlyDictionary<string, LoxoneControl> Controls => _uuidMap;
     public IReadOnlyDictionary<string, LoxoneRoom> Rooms => _roomMap;
     public IReadOnlyDictionary<string, LoxoneCategory> Categories => _categoryMap;
+    public IReadOnlyDictionary<int, string> GetOperatingModes() => _operatingModes;
 
     public async Task LoadAsync()
     {
@@ -72,6 +74,18 @@ public class LoxoneStructureState : ILoxoneStructureState
             {
                 var dto = kvp.Value;
                 _categoryMap[kvp.Key] = new LoxoneCategory(kvp.Key, dto.Name, dto.Type, dto.Color);
+            }
+        }
+
+        _operatingModes.Clear();
+        if (structure.OperatingModes is { } modes)
+        {
+            foreach (var kvp in modes)
+            {
+                if (int.TryParse(kvp.Key, out var id))
+                {
+                    _operatingModes[id] = kvp.Value.Name;
+                }
             }
         }
 

--- a/LoxNet.Client/Models/Structure/StructureDtos.cs
+++ b/LoxNet.Client/Models/Structure/StructureDtos.cs
@@ -9,6 +9,10 @@ namespace LoxNet;
 /// </summary>
 internal class StructureFileDto
 {
+    /// <summary>Dictionary of operating modes keyed by identifier.</summary>
+    [JsonPropertyName("operatingModes")]
+    public Dictionary<string, OperatingModeDto>? OperatingModes { get; set; }
+
     /// <summary>Dictionary of controls keyed by UUID.</summary>
     [JsonPropertyName("controls")]
     public Dictionary<string, ControlDto>? Controls { get; set; }
@@ -79,6 +83,15 @@ internal class ControlDto
 internal record PresetDto(
     [property: JsonPropertyName("uuid")] string Uuid,
     [property: JsonPropertyName("name")] string? Name);
+
+/// <summary>
+/// Model for an operating mode entry.
+/// </summary>
+internal class OperatingModeDto
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+}
 
 /// <summary>
 /// Model for a room entry from the structure file.

--- a/LoxNet.Client/OperationModes/CalendarMode.cs
+++ b/LoxNet.Client/OperationModes/CalendarMode.cs
@@ -1,0 +1,21 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Specifies when a scheduled operating mode becomes active.
+/// Values correspond to the Operating Mode Schedule documentation.
+/// </summary>
+public enum CalendarMode
+{
+    /// <summary>Specific date repeated every year.</summary>
+    YearlyDate = 0,
+    /// <summary>Date relative to Easter.</summary>
+    Easter = 1,
+    /// <summary>One specific date.</summary>
+    SpecificDate = 2,
+    /// <summary>Specific period between two dates.</summary>
+    SpecificTimespan = 3,
+    /// <summary>Repeated yearly timespan.</summary>
+    YearlyTimespan = 4,
+    /// <summary>One or more weekdays in specific months.</summary>
+    Weekday = 5
+}

--- a/LoxNet.Client/OperationModes/CalendarModeOption.cs
+++ b/LoxNet.Client/OperationModes/CalendarModeOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Provides query serialization for calendar mode attributes used when creating or updating entries.
+/// </summary>
+public interface ICalendarModeOption
+{
+    /// <summary>The calendar mode represented by this option.</summary>
+    CalendarMode Mode { get; }
+
+    /// <summary>Serializes the option to the calendar mode attribute string.</summary>
+    string ToQueryAttribute();
+}

--- a/LoxNet.Client/OperationModes/CalendarModeParser.cs
+++ b/LoxNet.Client/OperationModes/CalendarModeParser.cs
@@ -1,0 +1,43 @@
+namespace LoxNet.OperationModes;
+
+using System;
+
+/// <summary>
+/// Parses calendar mode attribute strings into concrete <see cref="ICalendarModeOption"/> instances.
+/// </summary>
+public static class CalendarModeParser
+{
+    /// <summary>
+    /// Parses an attribute string according to the given calendar mode.
+    /// </summary>
+    /// <param name="mode">The calendar mode.</param>
+    /// <param name="attribute">The attribute string from the schedule.</param>
+    /// <returns>The parsed option.</returns>
+    public static ICalendarModeOption Parse(CalendarMode mode, string attribute)
+    {
+        var parts = attribute.Split('/');
+        return mode switch
+        {
+            CalendarMode.YearlyDate => new YearlyDateOption((CalendarMonth)int.Parse(parts[0]), int.Parse(parts[1])),
+            CalendarMode.Easter => new EasterOption(int.Parse(attribute)),
+            CalendarMode.SpecificDate => new SpecificDateOption(int.Parse(parts[0]), (CalendarMonth)int.Parse(parts[1]), int.Parse(parts[2])),
+            CalendarMode.SpecificTimespan => new SpecificTimespanOption(
+                int.Parse(parts[0]),
+                (CalendarMonth)int.Parse(parts[1]),
+                int.Parse(parts[2]),
+                int.Parse(parts[3]),
+                (CalendarMonth)int.Parse(parts[4]),
+                int.Parse(parts[5])),
+            CalendarMode.YearlyTimespan => new YearlyTimespanOption(
+                (CalendarMonth)int.Parse(parts[0]),
+                int.Parse(parts[1]),
+                (CalendarMonth)int.Parse(parts[2]),
+                int.Parse(parts[3])),
+            CalendarMode.Weekday => new WeekdayOption(
+                (CalendarMonth)int.Parse(parts[0]),
+                (CalendarWeekday)int.Parse(parts[1]),
+                (WeekdayOccurrence)int.Parse(parts[2])),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode))
+        };
+    }
+}

--- a/LoxNet.Client/OperationModes/CalendarMonth.cs
+++ b/LoxNet.Client/OperationModes/CalendarMonth.cs
@@ -1,0 +1,35 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Month enumeration used for schedule options.
+/// Values correspond to the Operating Mode Schedule documentation.
+/// </summary>
+public enum CalendarMonth
+{
+    /// <summary>January.</summary>
+    January = 1,
+    /// <summary>February.</summary>
+    February = 2,
+    /// <summary>March.</summary>
+    March = 3,
+    /// <summary>April.</summary>
+    April = 4,
+    /// <summary>May.</summary>
+    May = 5,
+    /// <summary>June.</summary>
+    June = 6,
+    /// <summary>July.</summary>
+    July = 7,
+    /// <summary>August.</summary>
+    August = 8,
+    /// <summary>September.</summary>
+    September = 9,
+    /// <summary>October.</summary>
+    October = 10,
+    /// <summary>November.</summary>
+    November = 11,
+    /// <summary>December.</summary>
+    December = 12,
+    /// <summary>Every month.</summary>
+    Every = 13
+}

--- a/LoxNet.Client/OperationModes/CalendarWeekday.cs
+++ b/LoxNet.Client/OperationModes/CalendarWeekday.cs
@@ -1,0 +1,23 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Weekday enumeration used for schedule options.
+/// Values correspond to the Operating Mode Schedule documentation.
+/// </summary>
+public enum CalendarWeekday
+{
+    /// <summary>Monday.</summary>
+    Monday = 0,
+    /// <summary>Tuesday.</summary>
+    Tuesday = 1,
+    /// <summary>Wednesday.</summary>
+    Wednesday = 2,
+    /// <summary>Thursday.</summary>
+    Thursday = 3,
+    /// <summary>Friday.</summary>
+    Friday = 4,
+    /// <summary>Saturday.</summary>
+    Saturday = 5,
+    /// <summary>Sunday.</summary>
+    Sunday = 6
+}

--- a/LoxNet.Client/OperationModes/EasterOption.cs
+++ b/LoxNet.Client/OperationModes/EasterOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents <see cref="CalendarMode.Easter"/> attributes.
+/// </summary>
+public record EasterOption(int Offset) : ICalendarModeOption
+{
+    /// <inheritdoc />
+    public CalendarMode Mode => CalendarMode.Easter;
+
+    /// <inheritdoc />
+    public string ToQueryAttribute() => Offset.ToString();
+}

--- a/LoxNet.Client/OperationModes/IOperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/IOperatingModeService.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LoxNet;
+
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Provides access to the operating mode schedule endpoints.
+/// </summary>
+public interface IOperatingModeService
+{
+    /// <summary>Retrieves all schedule entries.</summary>
+    Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync();
+
+    /// <summary>Creates a new schedule entry.</summary>
+    Task<LoxoneMessage> CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode);
+
+    /// <summary>Updates an existing schedule entry.</summary>
+    Task<LoxoneMessage> UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode);
+
+    /// <summary>Deletes an entry by its UUID.</summary>
+    Task<LoxoneMessage> DeleteEntryAsync(string uuid);
+
+    /// <summary>Gets the configured heating period string.</summary>
+    Task<string> GetHeatPeriodAsync();
+
+    /// <summary>Gets the configured cooling period string.</summary>
+    Task<string> GetCoolPeriodAsync();
+}

--- a/LoxNet.Client/OperationModes/OperatingModeEntry.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeEntry.cs
@@ -1,0 +1,6 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents an entry in the operating mode schedule with a typed calendar mode option.
+/// </summary>
+public record OperatingModeEntry(string Uuid, string Name, string OperatingMode, ICalendarModeOption Mode);

--- a/LoxNet.Client/OperationModes/OperatingModeEntryDto.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeEntryDto.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO representing an entry in the operating mode schedule.
+/// </summary>
+public record OperatingModeEntryDto(
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("operatingMode")] string OperatingMode,
+    [property: JsonPropertyName("calMode")] CalendarMode CalendarMode,
+    [property: JsonPropertyName("calModeAttr")] string CalendarModeAttribute);

--- a/LoxNet.Client/OperationModes/OperatingModeEntryFactory.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeEntryFactory.cs
@@ -1,0 +1,16 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Converts <see cref="OperatingModeEntryDto"/> instances to typed <see cref="OperatingModeEntry"/> objects.
+/// </summary>
+public static class OperatingModeEntryFactory
+{
+    /// <summary>
+    /// Converts a DTO to a typed entry using the calendar mode parser.
+    /// </summary>
+    public static OperatingModeEntry FromDto(OperatingModeEntryDto dto)
+    {
+        var option = CalendarModeParser.Parse(dto.CalendarMode, dto.CalendarModeAttribute);
+        return new OperatingModeEntry(dto.Uuid, dto.Name, dto.OperatingMode, option);
+    }
+}

--- a/LoxNet.Client/OperationModes/OperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using LoxNet;
+
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Default implementation of <see cref="IOperatingModeService"/> using <see cref="ILoxoneHttpClient"/>.
+/// </summary>
+public class OperatingModeService : IOperatingModeService
+{
+    private readonly ILoxoneHttpClient _client;
+
+    /// <summary>Creates the service.</summary>
+    public OperatingModeService(ILoxoneHttpClient httpClient)
+    {
+        _client = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetentries");
+        var arr = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var dtos = JsonSerializer.Deserialize<OperatingModeEntryDto[]>(arr.GetRawText())!;
+        var list = new List<OperatingModeEntry>(dtos.Length);
+        foreach (var dto in dtos)
+        {
+            list.Add(OperatingModeEntryFactory.FromDto(dto));
+        }
+        return list;
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarcreateentry/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarupdateentry/{uuid}/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> DeleteEntryAsync(string uuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendardeleteentry/{uuid}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetHeatPeriodAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetheatperiod");
+        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetCoolPeriodAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetcoolperiod");
+        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+    }
+
+    private static LoxoneMessage ParseMessage(JsonDocument doc)
+    {
+        var ll = doc.RootElement.GetProperty("LL");
+        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
+        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+    }
+}

--- a/LoxNet.Client/OperationModes/SpecificDateOption.cs
+++ b/LoxNet.Client/OperationModes/SpecificDateOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents <see cref="CalendarMode.SpecificDate"/> attributes.
+/// </summary>
+public record SpecificDateOption(int Year, CalendarMonth Month, int Day) : ICalendarModeOption
+{
+    /// <inheritdoc />
+    public CalendarMode Mode => CalendarMode.SpecificDate;
+
+    /// <inheritdoc />
+    public string ToQueryAttribute() => $"{Year}/{(int)Month}/{Day}";
+}

--- a/LoxNet.Client/OperationModes/SpecificTimespanOption.cs
+++ b/LoxNet.Client/OperationModes/SpecificTimespanOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents <see cref="CalendarMode.SpecificTimespan"/> attributes.
+/// </summary>
+public record SpecificTimespanOption(int StartYear, CalendarMonth StartMonth, int StartDay, int EndYear, CalendarMonth EndMonth, int EndDay) : ICalendarModeOption
+{
+    /// <inheritdoc />
+    public CalendarMode Mode => CalendarMode.SpecificTimespan;
+
+    /// <inheritdoc />
+    public string ToQueryAttribute() => $"{StartYear}/{(int)StartMonth}/{StartDay}/{EndYear}/{(int)EndMonth}/{EndDay}";
+}

--- a/LoxNet.Client/OperationModes/WeekdayOccurrence.cs
+++ b/LoxNet.Client/OperationModes/WeekdayOccurrence.cs
@@ -1,0 +1,21 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Occurrence of a weekday within a month used for schedule options.
+/// Values correspond to the Operating Mode Schedule documentation.
+/// </summary>
+public enum WeekdayOccurrence
+{
+    /// <summary>Every occurrence.</summary>
+    Every = 0,
+    /// <summary>First occurrence.</summary>
+    First = 1,
+    /// <summary>Second occurrence.</summary>
+    Second = 2,
+    /// <summary>Third occurrence.</summary>
+    Third = 3,
+    /// <summary>Fourth occurrence.</summary>
+    Fourth = 4,
+    /// <summary>Last occurrence.</summary>
+    Last = 5
+}

--- a/LoxNet.Client/OperationModes/WeekdayOption.cs
+++ b/LoxNet.Client/OperationModes/WeekdayOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents <see cref="CalendarMode.Weekday"/> attributes.
+/// </summary>
+public record WeekdayOption(CalendarMonth Month, CalendarWeekday Weekday, WeekdayOccurrence WeekdayInMonth) : ICalendarModeOption
+{
+    /// <inheritdoc />
+    public CalendarMode Mode => CalendarMode.Weekday;
+
+    /// <inheritdoc />
+    public string ToQueryAttribute() => $"{(int)Month}/{(int)Weekday}/{(int)WeekdayInMonth}";
+}

--- a/LoxNet.Client/OperationModes/YearlyDateOption.cs
+++ b/LoxNet.Client/OperationModes/YearlyDateOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents <see cref="CalendarMode.YearlyDate"/> attributes.
+/// </summary>
+public record YearlyDateOption(CalendarMonth Month, int Day) : ICalendarModeOption
+{
+    /// <inheritdoc />
+    public CalendarMode Mode => CalendarMode.YearlyDate;
+
+    /// <inheritdoc />
+    public string ToQueryAttribute() => $"{(int)Month}/{Day}";
+}

--- a/LoxNet.Client/OperationModes/YearlyTimespanOption.cs
+++ b/LoxNet.Client/OperationModes/YearlyTimespanOption.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.OperationModes;
+
+/// <summary>
+/// Represents <see cref="CalendarMode.YearlyTimespan"/> attributes.
+/// </summary>
+public record YearlyTimespanOption(CalendarMonth StartMonth, int StartDay, CalendarMonth EndMonth, int EndDay) : ICalendarModeOption
+{
+    /// <inheritdoc />
+    public CalendarMode Mode => CalendarMode.YearlyTimespan;
+
+    /// <inheritdoc />
+    public string ToQueryAttribute() => $"{(int)StartMonth}/{StartDay}/{(int)EndMonth}/{EndDay}";
+}

--- a/LoxNet.Tests/OperatingModeServiceTests.cs
+++ b/LoxNet.Tests/OperatingModeServiceTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+using LoxNet;
+using LoxNet.OperationModes;
+
+namespace LoxNet.Tests;
+
+public class OperatingModeServiceTests
+{
+    private class MockHttpClient : ILoxoneHttpClient
+    {
+        public List<string> Paths { get; } = new();
+        public LoxoneConnectionOptions Options => new("localhost", 0, false);
+        public TokenInfo? LastToken => null;
+
+        private const string EntriesJson = "{\"LL\": { \"Code\": 200, \"value\": [ { \"uuid\": \"1\", \"name\": \"Entry\", \"operatingMode\": \"Party\", \"calMode\": 0, \"calModeAttr\": \"1/1\" } ] } }";
+        private const string OkJson = "{\"LL\": { \"Code\": 200 } }";
+        private const string HeatJson = "{\"LL\": { \"Code\": 200, \"value\": \"10-15/04-15\" } }";
+        private const string CoolJson = "{\"LL\": { \"Code\": 200, \"value\": \"06-01/09-30\" } }";
+
+        public Task<JsonDocument> RequestJsonAsync(string path)
+        {
+            Paths.Add(path);
+            var json = path switch
+            {
+                "jdev/sps/calendargetentries" => EntriesJson,
+                var p when p.StartsWith("jdev/sps/calendarcreateentry") => OkJson,
+                var p when p.StartsWith("jdev/sps/calendarupdateentry") => OkJson,
+                var p when p.StartsWith("jdev/sps/calendardeleteentry") => OkJson,
+                "jdev/sps/calendargetheatperiod" => HeatJson,
+                "jdev/sps/calendargetcoolperiod" => CoolJson,
+                _ => throw new System.InvalidOperationException(path)
+            };
+            return Task.FromResult(JsonDocument.Parse(json));
+        }
+
+        public Task<KeyInfo> GetKey2Async(string user) => throw new System.NotImplementedException();
+        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info) => throw new System.NotImplementedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task GetEntries_ReturnsParsedEntries()
+    {
+        var client = new MockHttpClient();
+        var svc = new OperatingModeService(client);
+
+        var entries = await svc.GetEntriesAsync();
+
+        Assert.Single(entries);
+        var e = entries[0];
+        Assert.Equal("1", e.Uuid);
+        Assert.Equal("Entry", e.Name);
+        Assert.Equal("Party", e.OperatingMode);
+        var option = Assert.IsType<YearlyDateOption>(e.Mode);
+        Assert.Equal(CalendarMonth.January, option.Month);
+        Assert.Equal(1, option.Day);
+        Assert.Contains("jdev/sps/calendargetentries", client.Paths);
+    }
+
+    [Fact]
+    public async Task Commands_ReturnOk()
+    {
+        var client = new MockHttpClient();
+        var svc = new OperatingModeService(client);
+
+        var mode = new YearlyDateOption(CalendarMonth.January, 1);
+        var c1 = await svc.CreateEntryAsync("Name", "Party", mode);
+        var c2 = await svc.UpdateEntryAsync("1", "Name", "Party", mode);
+        var c3 = await svc.DeleteEntryAsync("1");
+        var heat = await svc.GetHeatPeriodAsync();
+        var cool = await svc.GetCoolPeriodAsync();
+
+        Assert.Equal(200, c1.Code);
+        Assert.Equal(200, c2.Code);
+        Assert.Equal(200, c3.Code);
+        Assert.Equal("10-15/04-15", heat);
+        Assert.Equal("06-01/09-30", cool);
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/calendarcreateentry"));
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/calendarupdateentry/1"));
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/calendardeleteentry/1"));
+        Assert.Contains("jdev/sps/calendargetheatperiod", client.Paths);
+        Assert.Contains("jdev/sps/calendargetcoolperiod", client.Paths);
+    }
+
+    [Fact]
+    public void CalendarModeParser_ParsesWeekday()
+    {
+        var option = (WeekdayOption)CalendarModeParser.Parse(CalendarMode.Weekday, "1/0/1");
+        Assert.Equal(CalendarMonth.January, option.Month);
+        Assert.Equal(CalendarWeekday.Monday, option.Weekday);
+        Assert.Equal(WeekdayOccurrence.First, option.WeekdayInMonth);
+    }
+}

--- a/LoxNet.Tests/StructureCacheTests.cs
+++ b/LoxNet.Tests/StructureCacheTests.cs
@@ -10,6 +10,11 @@ public class StructureCacheTests
 {
     private const string SampleJson = """
 {
+  "operatingModes": {
+    "0": { "name": "Auto" },
+    "1": { "name": "Home" },
+    "2": { "name": "Away" }
+  },
   "controls": {
     "uuid-1": {
       "name": "Light",
@@ -119,6 +124,10 @@ public class StructureCacheTests
         Assert.Equal("Lighting", cat.Name);
         Assert.Equal("lights", cat.Type);
         Assert.Equal("#0000ff", cat.Color);
+
+        var modes = cache.GetOperatingModes();
+        Assert.Equal(3, modes.Count);
+        Assert.Equal("Home", modes[1]);
 
         Assert.True(cache.TryGetControl("uuid-2", out var lcCtrl));
         var lc = Assert.IsType<LightControllerV2>(lcCtrl);


### PR DESCRIPTION
## Summary
- define enums for calendar months, weekdays and weekday occurrences
- update option records to use the new enums
- add `CalendarModeParser` to convert attribute strings to option records
- include a parsing test for the weekday option
- map schedule entries to typed classes using a DTO factory

## Testing
- `dotnet test LoxNet.Tests/LoxNet.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_686addc10e90832691c287ead28d87f8