### PR TITLE
Handle custom user fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
   - <https://www.loxone.com/wp-content/uploads/datasheets/CommunicatingWithMiniserver.pdf>
   - <https://www.loxone.com/wp-content/uploads/datasheets/StructureFile.pdf>
   - <https://www.loxone.com/wp-content/uploads/datasheets/OperatingModeSchedule.pdf>
+  - <https://www.loxone.com/wp-content/uploads/datasheets/UserManagement.pdf>
 - To run the unit tests use the .NET SDK (9.0 or later):
   ```sh
   dotnet test LoxNet.Tests/LoxNet.Tests.csproj

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
   ```
 - All project code resides under `LoxNet.Client` and `LoxNet.Tests`.
 - C# code uses 4 spaces for indentation and `latest` language version.
+- When parsing JSON into models, use C# records and mark required fields with the `required` keyword.
 
 ## Development Notes
 - Command execution logic lives in `LoxoneControl` and is reused by derived controls.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@
 - All project code resides under `LoxNet.Client` and `LoxNet.Tests`.
 - C# code uses 4 spaces for indentation and `latest` language version.
 - When parsing JSON into models, use C# records and mark required fields with the `required` keyword.
-- Service methods must not return `LoxoneMessage`. Use `LoxoneMessageParser` to
-  parse responses and call `EnsureSuccess()` before returning strongly typed
-  results.
+- Service methods must not return `LoxoneMessage`. Always parse server
+  responses with `LoxoneMessageParser` and call `EnsureSuccess()` before
+  returning strongly typed results, even when a value is expected.
 
 ## Development Notes
 - Command execution logic lives in `LoxoneControl` and is reused by derived controls.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@
 - All project code resides under `LoxNet.Client` and `LoxNet.Tests`.
 - C# code uses 4 spaces for indentation and `latest` language version.
 - When parsing JSON into models, use C# records and mark required fields with the `required` keyword.
+- Service methods must not return `LoxoneMessage`. Use `LoxoneMessageParser` to
+  parse responses and call `EnsureSuccess()` before returning strongly typed
+  results.
 
 ## Development Notes
 - Command execution logic lives in `LoxoneControl` and is reused by derived controls.

--- a/LoxNet.Client/LoxoneHttpClient.cs
+++ b/LoxNet.Client/LoxoneHttpClient.cs
@@ -54,7 +54,9 @@ public class LoxoneHttpClient : ILoxoneHttpClient
     public async Task<KeyInfo> GetKey2Async(string user)
     {
         using var doc = await RequestJsonAsync($"jdev/sys/getkey2/{Uri.EscapeDataString(user)}");
-        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var value = msg.Value!.Value;
         return new KeyInfo(
             value.GetProperty("key").GetString()!,
             value.GetProperty("salt").GetString()!,
@@ -94,7 +96,9 @@ public class LoxoneHttpClient : ILoxoneHttpClient
         var uid = Guid.NewGuid().ToString("N");
         var encInfo = Uri.EscapeDataString(info);
         using var doc = await RequestJsonAsync($"jdev/sys/getjwt/{userHash}/{user}/{permission}/{uid}/{encInfo}");
-        var val = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var val = msg.Value!.Value;
         var token = new TokenInfo(
             val.GetProperty("token").GetString()!,
             val.GetProperty("validUntil").GetInt64(),

--- a/LoxNet.Client/LoxoneHttpClient.cs
+++ b/LoxNet.Client/LoxoneHttpClient.cs
@@ -56,7 +56,7 @@ public class LoxoneHttpClient : ILoxoneHttpClient
         using var doc = await RequestJsonAsync($"jdev/sys/getkey2/{Uri.EscapeDataString(user)}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var value = msg.Value!.Value;
+        var value = msg.Value;
         return new KeyInfo(
             value.GetProperty("key").GetString()!,
             value.GetProperty("salt").GetString()!,
@@ -98,7 +98,7 @@ public class LoxoneHttpClient : ILoxoneHttpClient
         using var doc = await RequestJsonAsync($"jdev/sys/getjwt/{userHash}/{user}/{permission}/{uid}/{encInfo}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var val = msg.Value!.Value;
+        var val = msg.Value;
         var token = new TokenInfo(
             val.GetProperty("token").GetString()!,
             val.GetProperty("validUntil").GetInt64(),

--- a/LoxNet.Client/LoxoneWebSocketClient.cs
+++ b/LoxNet.Client/LoxoneWebSocketClient.cs
@@ -64,10 +64,7 @@ public class LoxoneWebSocketClient : ILoxoneWebSocketClient
         await SendStringAsync(command);
         var response = await ReceiveStringAsync();
         using var doc = JsonDocument.Parse(response);
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement value = ll.TryGetProperty("value", out var v) ? v : default;
-        string? message = ll.TryGetProperty("value", out var msg) ? msg.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, message);
+        return LoxoneMessageParser.Parse(doc);
     }
 
     public async Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user)

--- a/LoxNet.Client/LoxoneWebSocketClient.cs
+++ b/LoxNet.Client/LoxoneWebSocketClient.cs
@@ -70,7 +70,9 @@ public class LoxoneWebSocketClient : ILoxoneWebSocketClient
     public async Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user)
     {
         using var doc = await _http.RequestJsonAsync("jdev/sys/getkey");
-        var key = HexUtils.FromHexString(doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!);
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var key = HexUtils.FromHexString(msg.Value!.Value.GetString()!);
         var digest = LoxoneHttpClient.HmacHex(key, Encoding.UTF8.GetBytes(token), System.Security.Cryptography.HashAlgorithmName.SHA1);
         return await SendCommandAsync($"authwithtoken/{digest}/{user}");
     }

--- a/LoxNet.Client/LoxoneWebSocketClient.cs
+++ b/LoxNet.Client/LoxoneWebSocketClient.cs
@@ -72,7 +72,7 @@ public class LoxoneWebSocketClient : ILoxoneWebSocketClient
         using var doc = await _http.RequestJsonAsync("jdev/sys/getkey");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var key = HexUtils.FromHexString(msg.Value!.Value.GetString()!);
+        var key = HexUtils.FromHexString(msg.Value.GetString()!);
         var digest = LoxoneHttpClient.HmacHex(key, Encoding.UTF8.GetBytes(token), System.Security.Cryptography.HashAlgorithmName.SHA1);
         return await SendCommandAsync($"authwithtoken/{digest}/{user}");
     }

--- a/LoxNet.Client/Models/LoxoneApiException.cs
+++ b/LoxNet.Client/Models/LoxoneApiException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace LoxNet;
+
+/// <summary>
+/// Exception thrown when the Miniserver returns a non-successful response code.
+/// </summary>
+public class LoxoneApiException : Exception
+{
+    /// <summary>The numeric response code.</summary>
+    public int Code { get; }
+
+    /// <summary>Creates the exception.</summary>
+    public LoxoneApiException(int code, string? message)
+        : base($"Server returned code {code}: {message}")
+    {
+        Code = code;
+    }
+}
+

--- a/LoxNet.Client/Models/LoxoneControl.cs
+++ b/LoxNet.Client/Models/LoxoneControl.cs
@@ -116,9 +116,6 @@ public class LoxoneControl
     protected async Task<LoxoneMessage> ExecuteCommandAsync(ILoxoneHttpClient client, string command)
     {
         using var doc = await client.RequestJsonAsync($"dev/sps/io/{UuidAction}/{command}");
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
-        string? message = ll.TryGetProperty("message", out var msg) ? msg.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, message);
+        return LoxoneMessageParser.Parse(doc);
     }
 }

--- a/LoxNet.Client/Models/LoxoneMessage.cs
+++ b/LoxNet.Client/Models/LoxoneMessage.cs
@@ -2,4 +2,16 @@ namespace LoxNet;
 
 using System.Text.Json;
 
-public record LoxoneMessage(int Code, JsonElement? Value, string? Message);
+public record LoxoneMessage(int Code, JsonElement? Value, string? Message)
+{
+    /// <summary>
+    /// Throws a <see cref="LoxoneApiException"/> if the message code is not 200.
+    /// </summary>
+    public void EnsureSuccess()
+    {
+        if (Code != 200)
+        {
+            throw new LoxoneApiException(Code, Message);
+        }
+    }
+}

--- a/LoxNet.Client/Models/LoxoneMessage.cs
+++ b/LoxNet.Client/Models/LoxoneMessage.cs
@@ -2,7 +2,17 @@ namespace LoxNet;
 
 using System.Text.Json;
 
-public record LoxoneMessage(int Code, JsonElement? Value, string? Message)
+/// <summary>
+/// Represents a raw response returned by the Miniserver.
+/// </summary>
+/// <param name="Code">The response code returned by the server.</param>
+/// <param name="Value">
+/// The value element returned by the server. If the response did not contain a
+/// <c>value</c> property this will be an empty <see cref="JsonElement"/> with
+/// <see cref="JsonValueKind.Undefined"/>.
+/// </param>
+/// <param name="Message">Optional message provided by the server.</param>
+public record LoxoneMessage(int Code, JsonElement Value, string? Message)
 {
     /// <summary>
     /// Throws a <see cref="LoxoneApiException"/> if the message code is not

--- a/LoxNet.Client/Models/LoxoneMessage.cs
+++ b/LoxNet.Client/Models/LoxoneMessage.cs
@@ -5,11 +5,12 @@ using System.Text.Json;
 public record LoxoneMessage(int Code, JsonElement? Value, string? Message)
 {
     /// <summary>
-    /// Throws a <see cref="LoxoneApiException"/> if the message code is not 200.
+    /// Throws a <see cref="LoxoneApiException"/> if the message code is not
+    /// within the HTTP success range (200-299).
     /// </summary>
     public void EnsureSuccess()
     {
-        if (Code != 200)
+        if (Code < 200 || Code >= 300)
         {
             throw new LoxoneApiException(Code, Message);
         }

--- a/LoxNet.Client/Models/LoxoneMessageParser.cs
+++ b/LoxNet.Client/Models/LoxoneMessageParser.cs
@@ -12,7 +12,7 @@ public static class LoxoneMessageParser
     public static LoxoneMessage Parse(JsonDocument doc)
     {
         var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        var value = ll.TryGetProperty("value", out var v) ? v : default;
         string? message = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
         return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, message);
     }

--- a/LoxNet.Client/Models/LoxoneMessageParser.cs
+++ b/LoxNet.Client/Models/LoxoneMessageParser.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace LoxNet;
+
+/// <summary>
+/// Provides helpers for parsing server responses into <see cref="LoxoneMessage"/> instances.
+/// </summary>
+public static class LoxoneMessageParser
+{
+    /// <summary>Parses a JSON document returned by the server.</summary>
+    /// <param name="doc">The document to parse.</param>
+    public static LoxoneMessage Parse(JsonDocument doc)
+    {
+        var ll = doc.RootElement.GetProperty("LL");
+        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        string? message = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
+        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, message);
+    }
+}
+

--- a/LoxNet.Client/OperationModes/IOperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/IOperatingModeService.cs
@@ -13,13 +13,13 @@ public interface IOperatingModeService
     Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync();
 
     /// <summary>Creates a new schedule entry.</summary>
-    Task<LoxoneMessage> CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode);
+    Task CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode);
 
     /// <summary>Updates an existing schedule entry.</summary>
-    Task<LoxoneMessage> UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode);
+    Task UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode);
 
     /// <summary>Deletes an entry by its UUID.</summary>
-    Task<LoxoneMessage> DeleteEntryAsync(string uuid);
+    Task DeleteEntryAsync(string uuid);
 
     /// <summary>Gets the configured heating period string.</summary>
     Task<string> GetHeatPeriodAsync();

--- a/LoxNet.Client/OperationModes/OperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeService.cs
@@ -25,7 +25,7 @@ public class OperatingModeService : IOperatingModeService
         using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetentries");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var arr = msg.Value!.Value;
+        var arr = msg.Value;
         var dtos = JsonSerializer.Deserialize<OperatingModeEntryDto[]>(arr.GetRawText())!;
         var list = new List<OperatingModeEntry>(dtos.Length);
         foreach (var dto in dtos)
@@ -62,7 +62,7 @@ public class OperatingModeService : IOperatingModeService
         using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetheatperiod");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        return msg.Value!.Value.GetString()!;
+        return msg.Value.GetString()!;
     }
 
     /// <inheritdoc />
@@ -71,7 +71,7 @@ public class OperatingModeService : IOperatingModeService
         using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetcoolperiod");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        return msg.Value!.Value.GetString()!;
+        return msg.Value.GetString()!;
     }
 
 }

--- a/LoxNet.Client/OperationModes/OperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeService.cs
@@ -23,7 +23,9 @@ public class OperatingModeService : IOperatingModeService
     public async Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetentries");
-        var arr = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var arr = msg.Value!.Value;
         var dtos = JsonSerializer.Deserialize<OperatingModeEntryDto[]>(arr.GetRawText())!;
         var list = new List<OperatingModeEntry>(dtos.Length);
         foreach (var dto in dtos)
@@ -58,14 +60,18 @@ public class OperatingModeService : IOperatingModeService
     public async Task<string> GetHeatPeriodAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetheatperiod");
-        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        return msg.Value!.Value.GetString()!;
     }
 
     /// <inheritdoc />
     public async Task<string> GetCoolPeriodAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetcoolperiod");
-        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        return msg.Value!.Value.GetString()!;
     }
 
 }

--- a/LoxNet.Client/OperationModes/OperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeService.cs
@@ -34,24 +34,24 @@ public class OperatingModeService : IOperatingModeService
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode)
+    public async Task CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarcreateentry/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode)
+    public async Task UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarupdateentry/{uuid}/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> DeleteEntryAsync(string uuid)
+    public async Task DeleteEntryAsync(string uuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/calendardeleteentry/{uuid}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
@@ -68,11 +68,4 @@ public class OperatingModeService : IOperatingModeService
         return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
     }
 
-    private static LoxoneMessage ParseMessage(JsonDocument doc)
-    {
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
-        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
-    }
 }

--- a/LoxNet.Client/Users/AddUser.cs
+++ b/LoxNet.Client/Users/AddUser.cs
@@ -1,0 +1,141 @@
+namespace LoxNet.Users;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Request payload for creating or editing a user when no UUID is required.
+/// Null properties are omitted from the serialized JSON.
+/// </summary>
+public class AddUser
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("desc")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("userid")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? UserId { get; init; }
+
+    [JsonPropertyName("firstname")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FirstName { get; init; }
+
+    [JsonPropertyName("lastname")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LastName { get; init; }
+
+    [JsonPropertyName("email")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Email { get; init; }
+
+    [JsonPropertyName("phone")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Phone { get; init; }
+
+    [JsonPropertyName("uniqueUserId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? UniqueUserId { get; init; }
+
+    [JsonPropertyName("company")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Company { get; init; }
+
+    [JsonPropertyName("department")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Department { get; init; }
+
+    [JsonPropertyName("personalno")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PersonalNo { get; init; }
+
+    [JsonPropertyName("title")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("debitor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Debitor { get; init; }
+
+    [JsonPropertyName("userState")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public UserState? UserState { get; init; }
+
+    [JsonPropertyName("isAdmin")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsAdmin { get; init; }
+
+    [JsonPropertyName("changePassword")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ChangePassword { get; init; }
+
+    [JsonPropertyName("masterAdmin")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? MasterAdmin { get; init; }
+
+    [JsonPropertyName("userRights")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public UserRights? UserRights { get; init; }
+
+    [JsonPropertyName("scorePWD")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ScorePwd { get; init; }
+
+    [JsonPropertyName("scoreVisuPWD")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ScoreVisuPwd { get; init; }
+
+    [JsonPropertyName("trustMember")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TrustMember { get; init; }
+
+    [JsonPropertyName("disabledBySource")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? DisabledBySource { get; init; }
+
+    [JsonPropertyName("validUntil")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonConverter(typeof(NullableUnixDateTimeConverter))]
+    public DateTime? ValidUntil { get; init; }
+
+    [JsonPropertyName("validFrom")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonConverter(typeof(NullableUnixDateTimeConverter))]
+    public DateTime? ValidFrom { get; init; }
+
+    [JsonPropertyName("expirationAction")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ExpirationAction? ExpirationAction { get; init; }
+
+    [JsonPropertyName("usergroups")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? UserGroups { get; init; }
+
+    [JsonPropertyName("nfcTags")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? NfcTags { get; init; }
+
+    [JsonPropertyName("keycodes")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? Keycodes { get; init; }
+
+    /// <summary>
+    /// Custom user field values ordered according to their index.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<string?> CustomFields
+        => Extra
+            .Where(p => p.Key.StartsWith("customField", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p.Key)
+            .Select(p => p.Value.ValueKind == JsonValueKind.Null ? null : p.Value.GetString())
+            .ToArray();
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> Extra { get; init; } = new();
+}

--- a/LoxNet.Client/Users/EditUser.cs
+++ b/LoxNet.Client/Users/EditUser.cs
@@ -1,0 +1,12 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Request payload for editing an existing user. Inherits all fields from <see cref="AddUser"/> and adds the required UUID.
+/// </summary>
+public class EditUser : AddUser
+{
+    [JsonPropertyName("uuid")]
+    public required string Uuid { get; init; }
+}

--- a/LoxNet.Client/Users/ExpirationAction.cs
+++ b/LoxNet.Client/Users/ExpirationAction.cs
@@ -1,0 +1,12 @@
+namespace LoxNet.Users;
+
+/// <summary>
+/// Action taken when a user's validity expires.
+/// </summary>
+public enum ExpirationAction
+{
+    /// <summary>Deactivate the user when expired.</summary>
+    Deactivate = 0,
+    /// <summary>Delete the user when expired.</summary>
+    Delete = 1
+}

--- a/LoxNet.Client/Users/IUserService.cs
+++ b/LoxNet.Client/Users/IUserService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Text.Json;
 using LoxNet;
 
 namespace LoxNet.Users;
@@ -78,4 +79,101 @@ public interface IUserService
     /// <param name="user">The configuration of the user to edit.</param>
     /// <returns>The updated <see cref="UserDetails"/> returned by the server.</returns>
     Task<UserDetails> EditUserAsync(EditUser user);
+
+    /// <summary>
+    /// Updates the hashed password of a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user.</param>
+    /// <param name="hash">The new hashed password value.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> UpdateUserPasswordHashAsync(string uuid, string hash);
+
+    /// <summary>
+    /// Updates the hashed visualization password of a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user.</param>
+    /// <param name="hash">The new hashed visu password.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> UpdateUserVisuPasswordHashAsync(string uuid, string hash);
+
+    /// <summary>
+    /// Updates the access code of a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user.</param>
+    /// <param name="accessCode">The new numeric access code.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> UpdateUserAccessCodeAsync(string uuid, string accessCode);
+
+    /// <summary>
+    /// Links an NFC tag with a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user.</param>
+    /// <param name="nfcTagId">The tag identifier.</param>
+    /// <param name="name">The label of the tag.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> AddUserNfcTagAsync(string uuid, string nfcTagId, string name);
+
+    /// <summary>
+    /// Removes an NFC tag from a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user.</param>
+    /// <param name="nfcTagId">The tag identifier.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> RemoveUserNfcTagAsync(string uuid, string nfcTagId);
+
+    /// <summary>
+    /// Retrieves permissions assigned directly to a control.
+    /// </summary>
+    /// <param name="uuid">The control UUID.</param>
+    /// <returns>The raw permissions document returned by the server.</returns>
+    Task<JsonDocument> GetControlPermissionsAsync(string uuid);
+
+    /// <summary>
+    /// Gets all configured values for user properties.
+    /// </summary>
+    /// <returns>Dictionary of property name to configured values.</returns>
+    Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync();
+
+    /// <summary>
+    /// Looks up a user by the configured user ID.
+    /// </summary>
+    /// <param name="userId">The user ID to search for.</param>
+    /// <returns>The matching user or <c>null</c> if not found.</returns>
+    Task<UserLookup?> CheckUserIdAsync(string userId);
+
+    /// <summary>
+    /// Retrieves the list of peers available for trust user management.
+    /// </summary>
+    /// <returns>List of peers.</returns>
+    Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync();
+
+    /// <summary>
+    /// Discovers users of a peer.
+    /// </summary>
+    /// <param name="peerSerial">The serial of the peer.</param>
+    /// <returns>The discovery result.</returns>
+    Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial);
+
+    /// <summary>
+    /// Adds a user from a peer via trust management.
+    /// </summary>
+    /// <param name="peerSerial">The peer serial.</param>
+    /// <param name="userUuid">UUID of the user to add.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> TrustAddUserAsync(string peerSerial, string userUuid);
+
+    /// <summary>
+    /// Removes a user from a peer via trust management.
+    /// </summary>
+    /// <param name="peerSerial">The peer serial.</param>
+    /// <param name="userUuid">UUID of the user to remove.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> TrustRemoveUserAsync(string peerSerial, string userUuid);
+
+    /// <summary>
+    /// Applies a trust user edit payload.
+    /// </summary>
+    /// <param name="json">The JSON body describing the changes.</param>
+    /// <returns>The server response code.</returns>
+    Task<LoxoneMessage> TrustEditAsync(string json);
 }

--- a/LoxNet.Client/Users/IUserService.cs
+++ b/LoxNet.Client/Users/IUserService.cs
@@ -41,24 +41,24 @@ public interface IUserService
     /// Deletes a user.
     /// </summary>
     /// <param name="uuid">The UUID of the user to delete.</param>
-    /// <returns>A message indicating the result of the operation.</returns>
-    Task<LoxoneMessage> DeleteUserAsync(string uuid);
+    /// <returns>A task that completes when the user is removed.</returns>
+    Task DeleteUserAsync(string uuid);
 
     /// <summary>
     /// Adds a user to a group.
     /// </summary>
     /// <param name="userUuid">The user's UUID.</param>
     /// <param name="groupUuid">The group's UUID.</param>
-    /// <returns>A message indicating the result of the assignment.</returns>
-    Task<LoxoneMessage> AssignUserToGroupAsync(string userUuid, string groupUuid);
+    /// <returns>A task that completes when the assignment is done.</returns>
+    Task AssignUserToGroupAsync(string userUuid, string groupUuid);
 
     /// <summary>
     /// Removes a user from a group.
     /// </summary>
     /// <param name="userUuid">The user's UUID.</param>
     /// <param name="groupUuid">The group's UUID.</param>
-    /// <returns>A message describing the outcome.</returns>
-    Task<LoxoneMessage> RemoveUserFromGroupAsync(string userUuid, string groupUuid);
+    /// <returns>A task that completes when the user is removed.</returns>
+    Task RemoveUserFromGroupAsync(string userUuid, string groupUuid);
 
     /// <summary>
     /// Retrieves the labels for configurable custom user fields.
@@ -85,24 +85,24 @@ public interface IUserService
     /// </summary>
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="hash">The new hashed password value.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> UpdateUserPasswordHashAsync(string uuid, string hash);
+    /// <returns>A task that completes when the password is updated.</returns>
+    Task UpdateUserPasswordHashAsync(string uuid, string hash);
 
     /// <summary>
     /// Updates the hashed visualization password of a user.
     /// </summary>
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="hash">The new hashed visu password.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> UpdateUserVisuPasswordHashAsync(string uuid, string hash);
+    /// <returns>A task that completes when the password is updated.</returns>
+    Task UpdateUserVisuPasswordHashAsync(string uuid, string hash);
 
     /// <summary>
     /// Updates the access code of a user.
     /// </summary>
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="accessCode">The new numeric access code.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> UpdateUserAccessCodeAsync(string uuid, string accessCode);
+    /// <returns>A task that completes when the code is updated.</returns>
+    Task UpdateUserAccessCodeAsync(string uuid, string accessCode);
 
     /// <summary>
     /// Links an NFC tag with a user.
@@ -110,16 +110,16 @@ public interface IUserService
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="nfcTagId">The tag identifier.</param>
     /// <param name="name">The label of the tag.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> AddUserNfcTagAsync(string uuid, string nfcTagId, string name);
+    /// <returns>A task that completes when the tag is added.</returns>
+    Task AddUserNfcTagAsync(string uuid, string nfcTagId, string name);
 
     /// <summary>
     /// Removes an NFC tag from a user.
     /// </summary>
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="nfcTagId">The tag identifier.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> RemoveUserNfcTagAsync(string uuid, string nfcTagId);
+    /// <returns>A task that completes when the tag is removed.</returns>
+    Task RemoveUserNfcTagAsync(string uuid, string nfcTagId);
 
     /// <summary>
     /// Retrieves permissions assigned directly to a control.
@@ -159,21 +159,21 @@ public interface IUserService
     /// </summary>
     /// <param name="peerSerial">The peer serial.</param>
     /// <param name="userUuid">UUID of the user to add.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> TrustAddUserAsync(string peerSerial, string userUuid);
+    /// <returns>A task that completes when the user is added.</returns>
+    Task TrustAddUserAsync(string peerSerial, string userUuid);
 
     /// <summary>
     /// Removes a user from a peer via trust management.
     /// </summary>
     /// <param name="peerSerial">The peer serial.</param>
     /// <param name="userUuid">UUID of the user to remove.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> TrustRemoveUserAsync(string peerSerial, string userUuid);
+    /// <returns>A task that completes when the user is removed.</returns>
+    Task TrustRemoveUserAsync(string peerSerial, string userUuid);
 
     /// <summary>
     /// Applies a trust user edit payload.
     /// </summary>
     /// <param name="json">The JSON body describing the changes.</param>
-    /// <returns>The server response code.</returns>
-    Task<LoxoneMessage> TrustEditAsync(string json);
+    /// <returns>A task that completes when the edit is applied.</returns>
+    Task TrustEditAsync(string json);
 }

--- a/LoxNet.Client/Users/IUserService.cs
+++ b/LoxNet.Client/Users/IUserService.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LoxNet;
+
+namespace LoxNet.Users;
+
+/// <summary>
+/// Provides access to user related endpoints.
+/// </summary>
+public interface IUserService
+{
+
+    /// <summary>
+    /// Retrieves a list of configured users.
+    /// </summary>
+    /// <returns>A collection of <see cref="UserSummary"/> records.</returns>
+    Task<IReadOnlyList<UserSummary>> GetUsersAsync();
+
+    /// <summary>
+    /// Gets the full configuration for a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user.</param>
+    /// <returns>The <see cref="UserDetails"/> for the user.</returns>
+    Task<UserDetails> GetUserAsync(string uuid);
+
+    /// <summary>
+    /// Gets the list of available user groups.
+    /// </summary>
+    /// <returns>A collection of <see cref="UserGroup"/> items.</returns>
+    Task<IReadOnlyList<UserGroup>> GetGroupsAsync();
+
+    /// <summary>
+    /// Creates a new user by username.
+    /// </summary>
+    /// <param name="username">The name of the new user.</param>
+    /// <returns>The UUID of the created user.</returns>
+    Task<string> CreateUserAsync(string username);
+
+    /// <summary>
+    /// Deletes a user.
+    /// </summary>
+    /// <param name="uuid">The UUID of the user to delete.</param>
+    /// <returns>A message indicating the result of the operation.</returns>
+    Task<LoxoneMessage> DeleteUserAsync(string uuid);
+
+    /// <summary>
+    /// Adds a user to a group.
+    /// </summary>
+    /// <param name="userUuid">The user's UUID.</param>
+    /// <param name="groupUuid">The group's UUID.</param>
+    /// <returns>A message indicating the result of the assignment.</returns>
+    Task<LoxoneMessage> AssignUserToGroupAsync(string userUuid, string groupUuid);
+
+    /// <summary>
+    /// Removes a user from a group.
+    /// </summary>
+    /// <param name="userUuid">The user's UUID.</param>
+    /// <param name="groupUuid">The group's UUID.</param>
+    /// <returns>A message describing the outcome.</returns>
+    Task<LoxoneMessage> RemoveUserFromGroupAsync(string userUuid, string groupUuid);
+
+    /// <summary>
+    /// Retrieves the labels for configurable custom user fields.
+    /// </summary>
+    /// <returns>An ordered list of field labels.</returns>
+    Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync();
+
+    /// <summary>
+    /// Adds a new user using the provided configuration.
+    /// </summary>
+    /// <param name="user">The configuration of the user to create.</param>
+    /// <returns>The created <see cref="UserDetails"/> returned by the server.</returns>
+    Task<UserDetails> AddUserAsync(AddUser user);
+
+    /// <summary>
+    /// Updates an existing user using the provided configuration.
+    /// </summary>
+    /// <param name="user">The configuration of the user to edit.</param>
+    /// <returns>The updated <see cref="UserDetails"/> returned by the server.</returns>
+    Task<UserDetails> EditUserAsync(EditUser user);
+}

--- a/LoxNet.Client/Users/Keycode.cs
+++ b/LoxNet.Client/Users/Keycode.cs
@@ -1,0 +1,9 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Hashed keycode assigned to a user.
+/// </summary>
+public record Keycode(
+    [property: JsonPropertyName("code")] string Code);

--- a/LoxNet.Client/Users/NfcTag.cs
+++ b/LoxNet.Client/Users/NfcTag.cs
@@ -1,0 +1,10 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// NFC tag assigned to a user.
+/// </summary>
+public record NfcTag(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("id")] string Id);

--- a/LoxNet.Client/Users/TrustDiscoveredUser.cs
+++ b/LoxNet.Client/Users/TrustDiscoveredUser.cs
@@ -1,0 +1,12 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents a user discovered on a peer during trust operations.
+/// </summary>
+public record TrustDiscoveredUser(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("used")] bool Used,
+    [property: JsonPropertyName("locked")] bool? Locked);

--- a/LoxNet.Client/Users/TrustDiscoveryResult.cs
+++ b/LoxNet.Client/Users/TrustDiscoveryResult.cs
@@ -1,0 +1,11 @@
+namespace LoxNet.Users;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Result returned when discovering users on a peer.
+/// </summary>
+public record TrustDiscoveryResult(
+    [property: JsonPropertyName("serial")] string Serial,
+    [property: JsonPropertyName("users")] IReadOnlyList<TrustDiscoveredUser> Users);

--- a/LoxNet.Client/Users/TrustPeer.cs
+++ b/LoxNet.Client/Users/TrustPeer.cs
@@ -1,0 +1,12 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents another Miniserver available for trust user management.
+/// </summary>
+public record TrustPeer(
+    [property: JsonPropertyName("serial")] string Serial,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("intAddr")] string IntAddr,
+    [property: JsonPropertyName("extAddr")] string ExtAddr);

--- a/LoxNet.Client/Users/UnixDateTimeConverter.cs
+++ b/LoxNet.Client/Users/UnixDateTimeConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LoxNet.Users;
+
+/// <summary>
+/// Converts Unix timestamps in seconds to <see cref="DateTime"/> values.
+/// </summary>
+public class UnixDateTimeConverter : JsonConverter<DateTime>
+{
+    /// <inheritdoc />
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64()).UtcDateTime;
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        => writer.WriteNumberValue(((DateTimeOffset)value).ToUnixTimeSeconds());
+}
+
+/// <summary>
+/// Handles nullable DateTime values represented as Unix timestamps.
+/// </summary>
+public class NullableUnixDateTimeConverter : JsonConverter<DateTime?>
+{
+    /// <inheritdoc />
+    public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType == JsonTokenType.Null
+            ? (DateTime?)null
+            : DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64()).UtcDateTime;
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteNumberValue(((DateTimeOffset)value.Value).ToUnixTimeSeconds());
+        }
+    }
+}

--- a/LoxNet.Client/Users/UserDetails.cs
+++ b/LoxNet.Client/Users/UserDetails.cs
@@ -1,0 +1,121 @@
+namespace LoxNet.Users;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Detailed configuration of a user as returned by getuser.
+/// Unknown properties are captured in <see cref="Extra"/>.
+/// </summary>
+public class UserDetails
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("desc")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("uuid")]
+    public required string Uuid { get; init; }
+
+    [JsonPropertyName("userid")]
+    public string? UserId { get; init; }
+
+    [JsonPropertyName("firstname")]
+    public string? FirstName { get; init; }
+
+    [JsonPropertyName("lastname")]
+    public string? LastName { get; init; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; init; }
+
+    [JsonPropertyName("phone")]
+    public string? Phone { get; init; }
+
+    [JsonPropertyName("uniqueUserId")]
+    public string? UniqueUserId { get; init; }
+
+    [JsonPropertyName("company")]
+    public string? Company { get; init; }
+
+    [JsonPropertyName("department")]
+    public string? Department { get; init; }
+
+    [JsonPropertyName("personalno")]
+    public string? PersonalNo { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("debitor")]
+    public string? Debitor { get; init; }
+
+    [JsonPropertyName("lastedit")]
+    [JsonConverter(typeof(NullableUnixDateTimeConverter))]
+    public DateTime? LastEdit { get; init; }
+
+    [JsonPropertyName("userState")]
+    public UserState UserState { get; init; }
+
+    [JsonPropertyName("isAdmin")]
+    public bool IsAdmin { get; init; }
+
+    [JsonPropertyName("changePassword")]
+    public bool? ChangePassword { get; init; }
+
+    [JsonPropertyName("masterAdmin")]
+    public bool? MasterAdmin { get; init; }
+
+    [JsonPropertyName("userRights")]
+    public UserRights? UserRights { get; init; }
+
+    [JsonPropertyName("scorePWD")]
+    public int? ScorePwd { get; init; }
+
+    [JsonPropertyName("scoreVisuPWD")]
+    public int? ScoreVisuPwd { get; init; }
+
+    [JsonPropertyName("trustMember")]
+    public string? TrustMember { get; init; }
+
+    [JsonPropertyName("disabledBySource")]
+    public bool? DisabledBySource { get; init; }
+
+    [JsonPropertyName("validUntil")]
+    [JsonConverter(typeof(NullableUnixDateTimeConverter))]
+    public DateTime? ValidUntil { get; init; }
+
+    [JsonPropertyName("validFrom")]
+    [JsonConverter(typeof(NullableUnixDateTimeConverter))]
+    public DateTime? ValidFrom { get; init; }
+
+    [JsonPropertyName("expirationAction")]
+    public ExpirationAction? ExpirationAction { get; init; }
+
+    [JsonPropertyName("usergroups")]
+    public IReadOnlyList<UserGroup>? UserGroups { get; init; }
+
+    [JsonPropertyName("nfcTags")]
+    public IReadOnlyList<NfcTag>? NfcTags { get; init; }
+
+    [JsonPropertyName("keycodes")]
+    public IReadOnlyList<Keycode>? Keycodes { get; init; }
+
+    /// <summary>
+    /// Custom user field values ordered according to their index.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<string?> CustomFields
+        => Extra
+            .Where(p => p.Key.StartsWith("customField", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(p => p.Key)
+            .Select(p => p.Value.ValueKind == JsonValueKind.Null ? null : p.Value.GetString())
+            .ToArray();
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> Extra { get; init; } = new();
+}

--- a/LoxNet.Client/Users/UserGroup.cs
+++ b/LoxNet.Client/Users/UserGroup.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents a user group as returned by getgrouplist.
+/// </summary>
+public record UserGroup(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("type")] UserGroupType Type,
+    [property: JsonPropertyName("userRights")] UserRights UserRights);

--- a/LoxNet.Client/Users/UserGroupType.cs
+++ b/LoxNet.Client/Users/UserGroupType.cs
@@ -1,0 +1,18 @@
+namespace LoxNet.Users;
+
+/// <summary>
+/// Classification of a user group as returned by the API.
+/// </summary>
+public enum UserGroupType
+{
+    /// <summary>Normal group.</summary>
+    Normal = 0,
+    /// <summary>Admin group (deprecated).</summary>
+    AdminDeprecated = 1,
+    /// <summary>Group containing all users.</summary>
+    All = 2,
+    /// <summary>Group for no users.</summary>
+    None = 3,
+    /// <summary>All-access administrative group.</summary>
+    AllAccess = 4
+}

--- a/LoxNet.Client/Users/UserLookup.cs
+++ b/LoxNet.Client/Users/UserLookup.cs
@@ -1,0 +1,10 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Minimal user information returned when looking up a user ID.
+/// </summary>
+public record UserLookup(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("uuid")] string Uuid);

--- a/LoxNet.Client/Users/UserRights.cs
+++ b/LoxNet.Client/Users/UserRights.cs
@@ -1,0 +1,32 @@
+namespace LoxNet.Users;
+
+using System;
+
+/// <summary>
+/// Flags representing permissions a user or group can have.
+/// Values correspond to the official user management specification.
+/// </summary>
+[Flags]
+public enum UserRights
+{
+    /// <summary>No additional rights.</summary>
+    None = 0x00000000,
+    /// <summary>Access to the web interface.</summary>
+    Web = 0x00000001,
+    /// <summary>Permission to configure the Miniserver using Loxone Config.</summary>
+    LoxoneConfig = 0x00000004,
+    /// <summary>Access to the FTP service.</summary>
+    Ftp = 0x00000008,
+    /// <summary>Access via Telnet.</summary>
+    Telnet = 0x00000010,
+    /// <summary>Permission to change operating modes.</summary>
+    OperatingModes = 0x00000020,
+    /// <summary>Permission to modify autopilot settings.</summary>
+    Autopilot = 0x00000040,
+    /// <summary>Expert mode Light access.</summary>
+    ExpertModeLight = 0x00000080,
+    /// <summary>Ability to manage other users.</summary>
+    UserManagement = 0x00000100,
+    /// <summary>All possible rights.</summary>
+    All = 0x00FFFFFF
+}

--- a/LoxNet.Client/Users/UserService.cs
+++ b/LoxNet.Client/Users/UserService.cs
@@ -52,33 +52,24 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> DeleteUserAsync(string uuid)
+    public async Task DeleteUserAsync(string uuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/deleteuser/{uuid}");
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
-        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> AssignUserToGroupAsync(string userUuid, string groupUuid)
+    public async Task AssignUserToGroupAsync(string userUuid, string groupUuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/assignusertogroup/{userUuid}/{groupUuid}");
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
-        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> RemoveUserFromGroupAsync(string userUuid, string groupUuid)
+    public async Task RemoveUserFromGroupAsync(string userUuid, string groupUuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/removeuserfromgroup/{userUuid}/{groupUuid}");
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
-        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
@@ -107,38 +98,38 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> UpdateUserPasswordHashAsync(string uuid, string hash)
+    public async Task UpdateUserPasswordHashAsync(string uuid, string hash)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuserpwdh/{uuid}/{hash}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> UpdateUserVisuPasswordHashAsync(string uuid, string hash)
+    public async Task UpdateUserVisuPasswordHashAsync(string uuid, string hash)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuservisupwdh/{uuid}/{hash}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> UpdateUserAccessCodeAsync(string uuid, string accessCode)
+    public async Task UpdateUserAccessCodeAsync(string uuid, string accessCode)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuseraccesscode/{uuid}/{accessCode}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> AddUserNfcTagAsync(string uuid, string nfcTagId, string name)
+    public async Task AddUserNfcTagAsync(string uuid, string nfcTagId, string name)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/addusernfc/{uuid}/{nfcTagId}/{Uri.EscapeDataString(name)}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> RemoveUserNfcTagAsync(string uuid, string nfcTagId)
+    public async Task RemoveUserNfcTagAsync(string uuid, string nfcTagId)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/removeusernfc/{uuid}/{nfcTagId}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
@@ -190,31 +181,24 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> TrustAddUserAsync(string peerSerial, string userUuid)
+    public async Task TrustAddUserAsync(string peerSerial, string userUuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/add/{peerSerial}/{userUuid}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> TrustRemoveUserAsync(string peerSerial, string userUuid)
+    public async Task TrustRemoveUserAsync(string peerSerial, string userUuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/remove/{peerSerial}/{userUuid}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<LoxoneMessage> TrustEditAsync(string json)
+    public async Task TrustEditAsync(string json)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/edit/{Uri.EscapeDataString(json)}");
-        return ParseMessage(doc);
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
-    private static LoxoneMessage ParseMessage(JsonDocument doc)
-    {
-        var ll = doc.RootElement.GetProperty("LL");
-        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
-        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
-        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
-    }
 }

--- a/LoxNet.Client/Users/UserService.cs
+++ b/LoxNet.Client/Users/UserService.cs
@@ -24,7 +24,9 @@ public class UserService : IUserService
     public async Task<IReadOnlyList<UserSummary>> GetUsersAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/getuserlist2");
-        var arr = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var arr = msg.Value!.Value;
         return JsonSerializer.Deserialize<UserSummary[]>(arr.GetRawText())!;
     }
 
@@ -32,7 +34,9 @@ public class UserService : IUserService
     public async Task<UserDetails> GetUserAsync(string uuid)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/getuser/{uuid}");
-        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var value = msg.Value!.Value;
         return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
     }
 
@@ -40,7 +44,9 @@ public class UserService : IUserService
     public async Task<IReadOnlyList<UserGroup>> GetGroupsAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/getgrouplist");
-        var arr = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var arr = msg.Value!.Value;
         return JsonSerializer.Deserialize<UserGroup[]>(arr.GetRawText())!;
     }
 
@@ -48,7 +54,9 @@ public class UserService : IUserService
     public async Task<string> CreateUserAsync(string username)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/createuser/{Uri.EscapeDataString(username)}");
-        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        return msg.Value!.Value.GetString()!;
     }
 
     /// <inheritdoc />
@@ -76,7 +84,9 @@ public class UserService : IUserService
     public async Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/getcustomuserfields");
-        var obj = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var obj = msg.Value!.Value;
         return obj.EnumerateObject()
             .OrderBy(p => p.Name)
             .Select(p => p.Value.GetString()!)
@@ -93,7 +103,9 @@ public class UserService : IUserService
     {
         var json = JsonSerializer.Serialize(user);
         using var doc = await _client.RequestJsonAsync($"jdev/sps/addoredituser/{Uri.EscapeDataString(json)}");
-        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var value = msg.Value!.Value;
         return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
     }
 
@@ -135,14 +147,18 @@ public class UserService : IUserService
     /// <inheritdoc />
     public async Task<JsonDocument> GetControlPermissionsAsync(string uuid)
     {
-        return await _client.RequestJsonAsync($"jdev/sps/getcontrolpermissions/{uuid}");
+        var doc = await _client.RequestJsonAsync($"jdev/sps/getcontrolpermissions/{uuid}");
+        LoxoneMessageParser.Parse(doc).EnsureSuccess();
+        return doc;
     }
 
     /// <inheritdoc />
     public async Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/getuserpropertyoptions");
-        var obj = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var obj = msg.Value!.Value;
         var dict = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         foreach (var prop in obj.EnumerateObject())
         {
@@ -156,7 +172,9 @@ public class UserService : IUserService
     public async Task<UserLookup?> CheckUserIdAsync(string userId)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/checkuserid/{Uri.EscapeDataString(userId)}");
-        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var value = msg.Value!.Value;
         if (value.TryGetProperty("uuid", out _))
         {
             return JsonSerializer.Deserialize<UserLookup>(value.GetRawText())!;
@@ -168,7 +186,9 @@ public class UserService : IUserService
     public async Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync()
     {
         using var doc = await _client.RequestJsonAsync("jdev/sps/trustusermanagement/peers");
-        var arr = doc.RootElement.GetProperty("LL").GetProperty("value").GetProperty("peers");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var arr = msg.Value!.Value.GetProperty("peers");
         return JsonSerializer.Deserialize<TrustPeer[]>(arr.GetRawText())!;
     }
 
@@ -176,7 +196,9 @@ public class UserService : IUserService
     public async Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial)
     {
         using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/discover/{peerSerial}");
-        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var msg = LoxoneMessageParser.Parse(doc);
+        msg.EnsureSuccess();
+        var value = msg.Value!.Value;
         return JsonSerializer.Deserialize<TrustDiscoveryResult>(value.GetRawText())!;
     }
 

--- a/LoxNet.Client/Users/UserService.cs
+++ b/LoxNet.Client/Users/UserService.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Linq;
+using LoxNet;
+
+namespace LoxNet.Users;
+
+/// <summary>
+/// Default implementation of <see cref="IUserService"/> using <see cref="ILoxoneHttpClient"/>.
+/// </summary>
+public class UserService : IUserService
+{
+    private readonly ILoxoneHttpClient _client;
+
+    /// <summary>Creates the service.</summary>
+    public UserService(ILoxoneHttpClient httpClient)
+    {
+        _client = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<UserSummary>> GetUsersAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getuserlist2");
+        var arr = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return JsonSerializer.Deserialize<UserSummary[]>(arr.GetRawText())!;
+    }
+
+    /// <inheritdoc />
+    public async Task<UserDetails> GetUserAsync(string uuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/getuser/{uuid}");
+        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<UserGroup>> GetGroupsAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getgrouplist");
+        var arr = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return JsonSerializer.Deserialize<UserGroup[]>(arr.GetRawText())!;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> CreateUserAsync(string username)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/createuser/{Uri.EscapeDataString(username)}");
+        return doc.RootElement.GetProperty("LL").GetProperty("value").GetString()!;
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> DeleteUserAsync(string uuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/deleteuser/{uuid}");
+        var ll = doc.RootElement.GetProperty("LL");
+        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
+        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> AssignUserToGroupAsync(string userUuid, string groupUuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/assignusertogroup/{userUuid}/{groupUuid}");
+        var ll = doc.RootElement.GetProperty("LL");
+        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
+        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> RemoveUserFromGroupAsync(string userUuid, string groupUuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/removeuserfromgroup/{userUuid}/{groupUuid}");
+        var ll = doc.RootElement.GetProperty("LL");
+        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
+        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getcustomuserfields");
+        var obj = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return obj.EnumerateObject()
+            .OrderBy(p => p.Name)
+            .Select(p => p.Value.GetString()!)
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public Task<UserDetails> AddUserAsync(AddUser user) => SendAddOrEditAsync(user);
+
+    /// <inheritdoc />
+    public Task<UserDetails> EditUserAsync(EditUser user) => SendAddOrEditAsync(user);
+
+    private async Task<UserDetails> SendAddOrEditAsync(AddUser user)
+    {
+        var json = JsonSerializer.Serialize(user);
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/addoredituser/{Uri.EscapeDataString(json)}");
+        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
+    }
+}

--- a/LoxNet.Client/Users/UserService.cs
+++ b/LoxNet.Client/Users/UserService.cs
@@ -105,4 +105,116 @@ public class UserService : IUserService
         var value = doc.RootElement.GetProperty("LL").GetProperty("value");
         return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
     }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> UpdateUserPasswordHashAsync(string uuid, string hash)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuserpwdh/{uuid}/{hash}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> UpdateUserVisuPasswordHashAsync(string uuid, string hash)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuservisupwdh/{uuid}/{hash}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> UpdateUserAccessCodeAsync(string uuid, string accessCode)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuseraccesscode/{uuid}/{accessCode}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> AddUserNfcTagAsync(string uuid, string nfcTagId, string name)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/addusernfc/{uuid}/{nfcTagId}/{Uri.EscapeDataString(name)}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> RemoveUserNfcTagAsync(string uuid, string nfcTagId)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/removeusernfc/{uuid}/{nfcTagId}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<JsonDocument> GetControlPermissionsAsync(string uuid)
+    {
+        return await _client.RequestJsonAsync($"jdev/sps/getcontrolpermissions/{uuid}");
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getuserpropertyoptions");
+        var obj = doc.RootElement.GetProperty("LL").GetProperty("value");
+        var dict = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var prop in obj.EnumerateObject())
+        {
+            var arr = prop.Value.EnumerateArray().Select(e => e.GetString()!).ToArray();
+            dict[prop.Name] = arr;
+        }
+        return dict;
+    }
+
+    /// <inheritdoc />
+    public async Task<UserLookup?> CheckUserIdAsync(string userId)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/checkuserid/{Uri.EscapeDataString(userId)}");
+        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        if (value.TryGetProperty("uuid", out _))
+        {
+            return JsonSerializer.Deserialize<UserLookup>(value.GetRawText())!;
+        }
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync()
+    {
+        using var doc = await _client.RequestJsonAsync("jdev/sps/trustusermanagement/peers");
+        var arr = doc.RootElement.GetProperty("LL").GetProperty("value").GetProperty("peers");
+        return JsonSerializer.Deserialize<TrustPeer[]>(arr.GetRawText())!;
+    }
+
+    /// <inheritdoc />
+    public async Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/discover/{peerSerial}");
+        var value = doc.RootElement.GetProperty("LL").GetProperty("value");
+        return JsonSerializer.Deserialize<TrustDiscoveryResult>(value.GetRawText())!;
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> TrustAddUserAsync(string peerSerial, string userUuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/add/{peerSerial}/{userUuid}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> TrustRemoveUserAsync(string peerSerial, string userUuid)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/remove/{peerSerial}/{userUuid}");
+        return ParseMessage(doc);
+    }
+
+    /// <inheritdoc />
+    public async Task<LoxoneMessage> TrustEditAsync(string json)
+    {
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/edit/{Uri.EscapeDataString(json)}");
+        return ParseMessage(doc);
+    }
+
+    private static LoxoneMessage ParseMessage(JsonDocument doc)
+    {
+        var ll = doc.RootElement.GetProperty("LL");
+        JsonElement? value = ll.TryGetProperty("value", out var v) ? v : (JsonElement?)null;
+        string? msg = ll.TryGetProperty("message", out var m) ? m.GetString() : null;
+        return new LoxoneMessage(ll.GetProperty("Code").GetInt32(), value, msg);
+    }
 }

--- a/LoxNet.Client/Users/UserService.cs
+++ b/LoxNet.Client/Users/UserService.cs
@@ -26,7 +26,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync("jdev/sps/getuserlist2");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var arr = msg.Value!.Value;
+        var arr = msg.Value;
         return JsonSerializer.Deserialize<UserSummary[]>(arr.GetRawText())!;
     }
 
@@ -36,7 +36,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync($"jdev/sps/getuser/{uuid}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var value = msg.Value!.Value;
+        var value = msg.Value;
         return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
     }
 
@@ -46,7 +46,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync("jdev/sps/getgrouplist");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var arr = msg.Value!.Value;
+        var arr = msg.Value;
         return JsonSerializer.Deserialize<UserGroup[]>(arr.GetRawText())!;
     }
 
@@ -56,7 +56,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync($"jdev/sps/createuser/{Uri.EscapeDataString(username)}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        return msg.Value!.Value.GetString()!;
+        return msg.Value.GetString()!;
     }
 
     /// <inheritdoc />
@@ -86,7 +86,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync("jdev/sps/getcustomuserfields");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var obj = msg.Value!.Value;
+        var obj = msg.Value;
         return obj.EnumerateObject()
             .OrderBy(p => p.Name)
             .Select(p => p.Value.GetString()!)
@@ -105,7 +105,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync($"jdev/sps/addoredituser/{Uri.EscapeDataString(json)}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var value = msg.Value!.Value;
+        var value = msg.Value;
         return JsonSerializer.Deserialize<UserDetails>(value.GetRawText())!;
     }
 
@@ -158,7 +158,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync("jdev/sps/getuserpropertyoptions");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var obj = msg.Value!.Value;
+        var obj = msg.Value;
         var dict = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         foreach (var prop in obj.EnumerateObject())
         {
@@ -174,7 +174,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync($"jdev/sps/checkuserid/{Uri.EscapeDataString(userId)}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var value = msg.Value!.Value;
+        var value = msg.Value;
         if (value.TryGetProperty("uuid", out _))
         {
             return JsonSerializer.Deserialize<UserLookup>(value.GetRawText())!;
@@ -188,7 +188,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync("jdev/sps/trustusermanagement/peers");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var arr = msg.Value!.Value.GetProperty("peers");
+        var arr = msg.Value.GetProperty("peers");
         return JsonSerializer.Deserialize<TrustPeer[]>(arr.GetRawText())!;
     }
 
@@ -198,7 +198,7 @@ public class UserService : IUserService
         using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/discover/{peerSerial}");
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
-        var value = msg.Value!.Value;
+        var value = msg.Value;
         return JsonSerializer.Deserialize<TrustDiscoveryResult>(value.GetRawText())!;
     }
 

--- a/LoxNet.Client/Users/UserState.cs
+++ b/LoxNet.Client/Users/UserState.cs
@@ -1,0 +1,19 @@
+namespace LoxNet.Users;
+
+/// <summary>
+/// Indicates whether a user is enabled and within which timeframe.
+/// Values correspond to the official user management specification.
+/// </summary>
+public enum UserState
+{
+    /// <summary>User is enabled without time limitation.</summary>
+    Enabled = 0,
+    /// <summary>User is disabled.</summary>
+    Disabled = 1,
+    /// <summary>User is enabled until a specific timestamp.</summary>
+    EnabledUntil = 2,
+    /// <summary>User is enabled only after a specific timestamp.</summary>
+    EnabledFrom = 3,
+    /// <summary>User is enabled within a time span.</summary>
+    EnabledBetween = 4
+}

--- a/LoxNet.Client/Users/UserSummary.cs
+++ b/LoxNet.Client/Users/UserSummary.cs
@@ -1,0 +1,13 @@
+namespace LoxNet.Users;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Basic information about a user as returned by getuserlist2.
+/// </summary>
+public record UserSummary(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("uuid")] string Uuid,
+    [property: JsonPropertyName("isAdmin")] bool IsAdmin,
+    [property: JsonPropertyName("userState")] UserState UserState,
+    [property: JsonPropertyName("expirationAction")] ExpirationAction? ExpirationAction);

--- a/LoxNet.Tests/OperatingModeServiceTests.cs
+++ b/LoxNet.Tests/OperatingModeServiceTests.cs
@@ -67,15 +67,12 @@ public class OperatingModeServiceTests
         var svc = new OperatingModeService(client);
 
         var mode = new YearlyDateOption(CalendarMonth.January, 1);
-        var c1 = await svc.CreateEntryAsync("Name", "Party", mode);
-        var c2 = await svc.UpdateEntryAsync("1", "Name", "Party", mode);
-        var c3 = await svc.DeleteEntryAsync("1");
+        await svc.CreateEntryAsync("Name", "Party", mode);
+        await svc.UpdateEntryAsync("1", "Name", "Party", mode);
+        await svc.DeleteEntryAsync("1");
         var heat = await svc.GetHeatPeriodAsync();
         var cool = await svc.GetCoolPeriodAsync();
 
-        Assert.Equal(200, c1.Code);
-        Assert.Equal(200, c2.Code);
-        Assert.Equal(200, c3.Code);
         Assert.Equal("10-15/04-15", heat);
         Assert.Equal("06-01/09-30", cool);
         Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/calendarcreateentry"));

--- a/LoxNet.Tests/StructureCacheTests.cs
+++ b/LoxNet.Tests/StructureCacheTests.cs
@@ -65,10 +65,10 @@ public class StructureCacheTests
         public event EventHandler<string>? MessageReceived;
         public Task ConnectAsync() => Task.CompletedTask;
         public Task CloseAsync() => Task.CompletedTask;
-        public Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user) => Task.FromResult(new LoxoneMessage(0, null, null));
-        public Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user) => Task.FromResult(new LoxoneMessage(0, null, null));
+        public Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user) => Task.FromResult(new LoxoneMessage(0, default, null));
+        public Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user) => Task.FromResult(new LoxoneMessage(0, default, null));
         public Task KeepAliveAsync() => Task.CompletedTask;
-        public Task<LoxoneMessage> CommandAsync(string path) => Task.FromResult(new LoxoneMessage(0, null, null));
+        public Task<LoxoneMessage> CommandAsync(string path) => Task.FromResult(new LoxoneMessage(0, default, null));
         public Task ListenAsync(System.Threading.CancellationToken cancellationToken = default) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 

--- a/LoxNet.Tests/UserServiceTests.cs
+++ b/LoxNet.Tests/UserServiceTests.cs
@@ -100,9 +100,9 @@ public class UserServiceTests
         var user = await svc.GetUserAsync("1");
         var groups = await svc.GetGroupsAsync();
         var uuid = await svc.CreateUserAsync("name");
-        var del = await svc.DeleteUserAsync("1");
-        var add = await svc.AssignUserToGroupAsync("1", "g1");
-        var rem = await svc.RemoveUserFromGroupAsync("1", "g1");
+        await svc.DeleteUserAsync("1");
+        await svc.AssignUserToGroupAsync("1", "g1");
+        await svc.RemoveUserFromGroupAsync("1", "g1");
         var created = await svc.AddUserAsync(new AddUser { Name = "x" });
         var edit = await svc.EditUserAsync(new EditUser { Name = "x", Uuid = "1" });
 
@@ -110,9 +110,6 @@ public class UserServiceTests
         Assert.Single(groups);
         Assert.Equal(UserGroupType.AdminDeprecated, groups[0].Type);
         Assert.Equal("u1", uuid);
-        Assert.Equal(200, del.Code);
-        Assert.Equal(200, add.Code);
-        Assert.Equal(200, rem.Code);
         Assert.Equal("admin", created.Name);
         Assert.Equal("admin", edit.Name);
         Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/getuser/1"));
@@ -130,33 +127,25 @@ public class UserServiceTests
         var client = new MockHttpClient();
         var svc = new UserService(client);
 
-        var pwd = await svc.UpdateUserPasswordHashAsync("1", "h");
-        var visu = await svc.UpdateUserVisuPasswordHashAsync("1", "h");
-        var code = await svc.UpdateUserAccessCodeAsync("1", "1234");
-        var addTag = await svc.AddUserNfcTagAsync("1", "n1", "t");
-        var remTag = await svc.RemoveUserNfcTagAsync("1", "n1");
+        await svc.UpdateUserPasswordHashAsync("1", "h");
+        await svc.UpdateUserVisuPasswordHashAsync("1", "h");
+        await svc.UpdateUserAccessCodeAsync("1", "1234");
+        await svc.AddUserNfcTagAsync("1", "n1", "t");
+        await svc.RemoveUserNfcTagAsync("1", "n1");
         using var perms = await svc.GetControlPermissionsAsync("c1");
         var options = await svc.GetUserPropertyOptionsAsync();
         var lookup = await svc.CheckUserIdAsync("uid");
         var peers = await svc.GetTrustPeersAsync();
         var disc = await svc.DiscoverTrustUsersAsync("p1");
-        var tAdd = await svc.TrustAddUserAsync("p1", "u1");
-        var tRem = await svc.TrustRemoveUserAsync("p1", "u1");
-        var tEdit = await svc.TrustEditAsync("{}");
+        await svc.TrustAddUserAsync("p1", "u1");
+        await svc.TrustRemoveUserAsync("p1", "u1");
+        await svc.TrustEditAsync("{}");
 
-        Assert.Equal(200, pwd.Code);
-        Assert.Equal(200, visu.Code);
-        Assert.Equal(200, code.Code);
-        Assert.Equal(200, addTag.Code);
-        Assert.Equal(200, remTag.Code);
         Assert.Equal(200, perms.RootElement.GetProperty("LL").GetProperty("Code").GetInt32());
         Assert.Contains("Loxone", options["company"]);
         Assert.Equal("admin", lookup!.Name);
         Assert.Equal("Peer", peers[0].Name);
         Assert.Equal("p1", disc.Serial);
-        Assert.Equal(200, tAdd.Code);
-        Assert.Equal(200, tRem.Code);
-        Assert.Equal(200, tEdit.Code);
 
         Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/updateuserpwdh/1"));
         Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/updateuservisupwdh/1"));

--- a/LoxNet.Tests/UserServiceTests.cs
+++ b/LoxNet.Tests/UserServiceTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+using LoxNet;
+using LoxNet.Users;
+
+namespace LoxNet.Tests;
+
+public class UserServiceTests
+{
+    private class MockHttpClient : ILoxoneHttpClient
+    {
+        public List<string> Paths { get; } = new();
+        public LoxoneConnectionOptions Options => new("localhost", 0, false);
+        public TokenInfo? LastToken => null;
+
+        private const string ListJson = "{\"LL\":{\"Code\":200,\"value\":[{\"name\":\"admin\",\"uuid\":\"1\",\"isAdmin\":true,\"userState\":0}]}}";
+        private const string UserJson = "{\"LL\":{\"Code\":200,\"value\":{\"name\":\"admin\",\"uuid\":\"1\",\"userid\":\"123\",\"isAdmin\":true,\"userState\":0}}}";
+        private const string GroupJson = "{\"LL\":{\"Code\":200,\"value\":[{\"name\":\"Group\",\"description\":\"desc\",\"uuid\":\"g1\",\"type\":1,\"userRights\":2}]}}";
+        private const string UuidJson = "{\"LL\":{\"Code\":200,\"value\":\"u1\"}}";
+        private const string OkJson = "{\"LL\":{\"Code\":200}}";
+        private const string FieldsJson = "{\"LL\":{\"Code\":200,\"value\":{\"customField1\":\"Building\",\"customField2\":\"Space\"}}}";
+
+        public Task<JsonDocument> RequestJsonAsync(string path)
+        {
+            Paths.Add(path);
+            var json = path switch
+            {
+                "jdev/sps/getuserlist2" => ListJson,
+                var p when p.StartsWith("jdev/sps/getuser/") => UserJson,
+                "jdev/sps/getgrouplist" => GroupJson,
+                var p when p.StartsWith("jdev/sps/createuser") => UuidJson,
+                var p when p.StartsWith("jdev/sps/deleteuser") => OkJson,
+                var p when p.StartsWith("jdev/sps/assignusertogroup") => OkJson,
+                var p when p.StartsWith("jdev/sps/removeuserfromgroup") => OkJson,
+                var p when p.StartsWith("jdev/sps/addoredituser") => UserJson,
+                "jdev/sps/getcustomuserfields" => FieldsJson,
+                _ => throw new System.InvalidOperationException(path)
+            };
+            return Task.FromResult(JsonDocument.Parse(json));
+        }
+
+        public Task<KeyInfo> GetKey2Async(string user) => throw new System.NotImplementedException();
+        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info) => throw new System.NotImplementedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task GetUsers_ReturnsList()
+    {
+        var client = new MockHttpClient();
+        var svc = new UserService(client);
+
+        var list = await svc.GetUsersAsync();
+
+        Assert.Single(list);
+        Assert.Equal("admin", list[0].Name);
+        Assert.Equal(UserState.Enabled, list[0].UserState);
+        Assert.Contains("jdev/sps/getuserlist2", client.Paths);
+    }
+
+    [Fact]
+    public async Task GetCustomFieldLabels_ReturnsList()
+    {
+        var client = new MockHttpClient();
+        var svc = new UserService(client);
+
+        var labels = await svc.GetCustomFieldLabelsAsync();
+
+        Assert.Equal("Building", labels[0]);
+        Assert.Equal("Space", labels[1]);
+        Assert.Contains("jdev/sps/getcustomuserfields", client.Paths);
+    }
+
+    [Fact]
+    public async Task Commands_ReturnOk()
+    {
+        var client = new MockHttpClient();
+        var svc = new UserService(client);
+
+        var user = await svc.GetUserAsync("1");
+        var groups = await svc.GetGroupsAsync();
+        var uuid = await svc.CreateUserAsync("name");
+        var del = await svc.DeleteUserAsync("1");
+        var add = await svc.AssignUserToGroupAsync("1", "g1");
+        var rem = await svc.RemoveUserFromGroupAsync("1", "g1");
+        var created = await svc.AddUserAsync(new AddUser { Name = "x" });
+        var edit = await svc.EditUserAsync(new EditUser { Name = "x", Uuid = "1" });
+
+        Assert.Equal("admin", user.Name);
+        Assert.Single(groups);
+        Assert.Equal(UserGroupType.AdminDeprecated, groups[0].Type);
+        Assert.Equal("u1", uuid);
+        Assert.Equal(200, del.Code);
+        Assert.Equal(200, add.Code);
+        Assert.Equal(200, rem.Code);
+        Assert.Equal("admin", created.Name);
+        Assert.Equal("admin", edit.Name);
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/getuser/1"));
+        Assert.Contains("jdev/sps/getgrouplist", client.Paths);
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/createuser"));
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/deleteuser/1"));
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/assignusertogroup/1/g1"));
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/removeuserfromgroup/1/g1"));
+        Assert.Contains(client.Paths, p => p.StartsWith("jdev/sps/addoredituser"));
+    }
+}


### PR DESCRIPTION
## Summary
- move custom fields into ordered list in `UserDetails`
- `GetCustomFieldLabelsAsync` returns list instead of dictionary
- update implementation and tests for new list-based custom field handling
- use `required` keyword for mandatory strings
- add AddUser/EditUser request models to omit uuid when not editing
- split add/edit user endpoints and represent time fields as `DateTime`
- convert `UserRights` integer values into flag enum

## Testing
- `dotnet test LoxNet.Tests/LoxNet.Tests.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdb2d55c083269afc27bb7ff63157