### PR TITLE
Add cancellation tokens and ConfigureAwait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,4 @@
 - JSON from `LoxApp3.json` is deserialized into DTO classes decorated with `JsonPropertyName` attributes.
 - Command methods on control classes and detail properties include XML documentation.
 - Typed controls like `LightControllerV2` and `SwitchControl` expose `Details` objects parsed during factory creation.
+- All async methods expose an optional `CancellationToken` parameter and await calls using `ConfigureAwait(false)`.

--- a/LoxNet.Client/Controls/LightController.cs
+++ b/LoxNet.Client/Controls/LightController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace LoxNet;
 
@@ -23,17 +24,17 @@ public class LightController : LoxoneControl<LightControllerDetails>
     /// <summary>
     /// Turns the light controller on.
     /// </summary>
-    public async Task<LoxoneMessage> SwitchOnAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> SwitchOnAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "on");
+        return await ExecuteCommandAsync(client, "on", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Turns the light controller off.
     /// </summary>
-    public async Task<LoxoneMessage> SwitchOffAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> SwitchOffAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "off");
+        return await ExecuteCommandAsync(client, "off", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -41,8 +42,8 @@ public class LightController : LoxoneControl<LightControllerDetails>
     /// </summary>
     /// <param name="client">HTTP client used for the command.</param>
     /// <param name="scene">Scene number to activate.</param>
-    public async Task<LoxoneMessage> SetSceneAsync(ILoxoneHttpClient client, int scene)
+    public async Task<LoxoneMessage> SetSceneAsync(ILoxoneHttpClient client, int scene, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"scene/{scene}");
+        return await ExecuteCommandAsync(client, $"scene/{scene}", cancellationToken).ConfigureAwait(false);
     }
 }

--- a/LoxNet.Client/Controls/LightControllerV2.cs
+++ b/LoxNet.Client/Controls/LightControllerV2.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LoxNet;
@@ -25,116 +26,116 @@ public class LightControllerV2 : LoxoneControl<LightControllerV2Details>
     /// <summary>Changes directly to the specified mood.</summary>
     /// <param name="client">HTTP client used for the command.</param>
     /// <param name="moodId">Identifier of the mood.</param>
-    public async Task<LoxoneMessage> ChangeToAsync(ILoxoneHttpClient client, string moodId)
+    public async Task<LoxoneMessage> ChangeToAsync(ILoxoneHttpClient client, string moodId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"changeTo/{moodId}");
+        return await ExecuteCommandAsync(client, $"changeTo/{moodId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Adds a mood to the set of active moods.</summary>
-    public async Task<LoxoneMessage> AddMoodAsync(ILoxoneHttpClient client, string moodId)
+    public async Task<LoxoneMessage> AddMoodAsync(ILoxoneHttpClient client, string moodId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"addMood/{moodId}");
+        return await ExecuteCommandAsync(client, $"addMood/{moodId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Removes a mood from the set of active moods.</summary>
-    public async Task<LoxoneMessage> RemoveMoodAsync(ILoxoneHttpClient client, string moodId)
+    public async Task<LoxoneMessage> RemoveMoodAsync(ILoxoneHttpClient client, string moodId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"removeMood/{moodId}");
+        return await ExecuteCommandAsync(client, $"removeMood/{moodId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Moves a favorite mood to a new index.</summary>
-    public async Task<LoxoneMessage> MoveFavoriteMoodAsync(ILoxoneHttpClient client, string moodId, int newIndex)
+    public async Task<LoxoneMessage> MoveFavoriteMoodAsync(ILoxoneHttpClient client, string moodId, int newIndex, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"moveFavoriteMood/{moodId}/{newIndex}");
+        return await ExecuteCommandAsync(client, $"moveFavoriteMood/{moodId}/{newIndex}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Moves an additional mood to a new index.</summary>
-    public async Task<LoxoneMessage> MoveAdditionalMoodAsync(ILoxoneHttpClient client, string moodId, int newIndex)
+    public async Task<LoxoneMessage> MoveAdditionalMoodAsync(ILoxoneHttpClient client, string moodId, int newIndex, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"moveAdditionalMood/{moodId}/{newIndex}");
+        return await ExecuteCommandAsync(client, $"moveAdditionalMood/{moodId}/{newIndex}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Moves a mood in the complete mood list.</summary>
-    public async Task<LoxoneMessage> MoveMoodAsync(ILoxoneHttpClient client, string moodId, int newIndex)
+    public async Task<LoxoneMessage> MoveMoodAsync(ILoxoneHttpClient client, string moodId, int newIndex, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"moveMood/{moodId}/{newIndex}");
+        return await ExecuteCommandAsync(client, $"moveMood/{moodId}/{newIndex}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Adds the specified mood to the favorites list.</summary>
-    public async Task<LoxoneMessage> AddToFavoriteMoodAsync(ILoxoneHttpClient client, string moodId)
+    public async Task<LoxoneMessage> AddToFavoriteMoodAsync(ILoxoneHttpClient client, string moodId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"addToFavoriteMood/{moodId}");
+        return await ExecuteCommandAsync(client, $"addToFavoriteMood/{moodId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Removes the specified mood from the favorites list.</summary>
-    public async Task<LoxoneMessage> RemoveFromFavoriteMoodAsync(ILoxoneHttpClient client, string moodId)
+    public async Task<LoxoneMessage> RemoveFromFavoriteMoodAsync(ILoxoneHttpClient client, string moodId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"removeFromFavoriteMood/{moodId}");
+        return await ExecuteCommandAsync(client, $"removeFromFavoriteMood/{moodId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Stores the current values as a new mood.</summary>
-    public async Task<LoxoneMessage> LearnAsync(ILoxoneHttpClient client, string moodId, string moodName)
+    public async Task<LoxoneMessage> LearnAsync(ILoxoneHttpClient client, string moodId, string moodName, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"learn/{moodId}/{Uri.EscapeDataString(moodName)}");
+        return await ExecuteCommandAsync(client, $"learn/{moodId}/{Uri.EscapeDataString(moodName)}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Deletes the specified mood.</summary>
-    public async Task<LoxoneMessage> DeleteMoodAsync(ILoxoneHttpClient client, string moodId)
+    public async Task<LoxoneMessage> DeleteMoodAsync(ILoxoneHttpClient client, string moodId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"delete/{moodId}");
+        return await ExecuteCommandAsync(client, $"delete/{moodId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Advances to the next mood.</summary>
-    public async Task<LoxoneMessage> PlusAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> PlusAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "plus");
+        return await ExecuteCommandAsync(client, "plus", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Switches to the previous mood.</summary>
-    public async Task<LoxoneMessage> MinusAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> MinusAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "minus");
+        return await ExecuteCommandAsync(client, "minus", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Changes the identifier of an existing mood.</summary>
-    public async Task<LoxoneMessage> SetMoodIdAsync(ILoxoneHttpClient client, string currentId, string newId)
+    public async Task<LoxoneMessage> SetMoodIdAsync(ILoxoneHttpClient client, string currentId, string newId, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"setmoodid/{currentId}/{newId}");
+        return await ExecuteCommandAsync(client, $"setmoodid/{currentId}/{newId}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Sets the short name of a mood.</summary>
-    public async Task<LoxoneMessage> SetMoodShortNameAsync(ILoxoneHttpClient client, string moodId, string shortName)
+    public async Task<LoxoneMessage> SetMoodShortNameAsync(ILoxoneHttpClient client, string moodId, string shortName, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"setmoodshortname/{moodId}/{Uri.EscapeDataString(shortName)}");
+        return await ExecuteCommandAsync(client, $"setmoodshortname/{moodId}/{Uri.EscapeDataString(shortName)}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Sets the full name of a mood.</summary>
-    public async Task<LoxoneMessage> SetMoodNameAsync(ILoxoneHttpClient client, string moodId, string name)
+    public async Task<LoxoneMessage> SetMoodNameAsync(ILoxoneHttpClient client, string moodId, string name, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"setmoodname/{moodId}/{Uri.EscapeDataString(name)}");
+        return await ExecuteCommandAsync(client, $"setmoodname/{moodId}/{Uri.EscapeDataString(name)}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Updates circuit names using a JSON payload.</summary>
-    public async Task<LoxoneMessage> SetCircuitNamesAsync(ILoxoneHttpClient client, string json)
+    public async Task<LoxoneMessage> SetCircuitNamesAsync(ILoxoneHttpClient client, string json, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"setcircuitnames/{Uri.EscapeDataString(json)}");
+        return await ExecuteCommandAsync(client, $"setcircuitnames/{Uri.EscapeDataString(json)}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Updates the daylight configuration using a JSON payload.</summary>
-    public async Task<LoxoneMessage> SetDaylightConfigAsync(ILoxoneHttpClient client, string json)
+    public async Task<LoxoneMessage> SetDaylightConfigAsync(ILoxoneHttpClient client, string json, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, $"setdaylightconfig/{Uri.EscapeDataString(json)}");
+        return await ExecuteCommandAsync(client, $"setdaylightconfig/{Uri.EscapeDataString(json)}", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Enables presence functionality.</summary>
-    public async Task<LoxoneMessage> PresenceOnAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> PresenceOnAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "presence/on");
+        return await ExecuteCommandAsync(client, "presence/on", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Disables presence functionality.</summary>
-    public async Task<LoxoneMessage> PresenceOffAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> PresenceOffAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "presence/off");
+        return await ExecuteCommandAsync(client, "presence/off", cancellationToken).ConfigureAwait(false);
     }
 }

--- a/LoxNet.Client/Controls/SwitchControl.cs
+++ b/LoxNet.Client/Controls/SwitchControl.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace LoxNet;
 
@@ -18,26 +19,26 @@ public class SwitchControl : LoxoneControl<SwitchControlDetails>
     /// Turns the switch on.
     /// </summary>
     /// <param name="client">HTTP client used to send the command.</param>
-    public async Task<LoxoneMessage> OnAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> OnAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "on");
+        return await ExecuteCommandAsync(client, "on", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Turns the switch off.
     /// </summary>
     /// <param name="client">HTTP client used to send the command.</param>
-    public async Task<LoxoneMessage> OffAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> OffAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "off");
+        return await ExecuteCommandAsync(client, "off", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Pulses the switch.
     /// </summary>
     /// <param name="client">HTTP client used to send the command.</param>
-    public async Task<LoxoneMessage> PulseAsync(ILoxoneHttpClient client)
+    public async Task<LoxoneMessage> PulseAsync(ILoxoneHttpClient client, CancellationToken cancellationToken = default)
     {
-        return await ExecuteCommandAsync(client, "pulse");
+        return await ExecuteCommandAsync(client, "pulse", cancellationToken).ConfigureAwait(false);
     }
 }

--- a/LoxNet.Client/Interfaces/ILoxoneHttpClient.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneHttpClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LoxNet;
@@ -8,7 +9,7 @@ public interface ILoxoneHttpClient : IAsyncDisposable
 {
     LoxoneConnectionOptions Options { get; }
     TokenInfo? LastToken { get; }
-    Task<JsonDocument> RequestJsonAsync(string path);
-    Task<KeyInfo> GetKey2Async(string user);
-    Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info);
+    Task<JsonDocument> RequestJsonAsync(string path, CancellationToken cancellationToken = default);
+    Task<KeyInfo> GetKey2Async(string user, CancellationToken cancellationToken = default);
+    Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info, CancellationToken cancellationToken = default);
 }

--- a/LoxNet.Client/Interfaces/ILoxoneStructureState.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneStructureState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LoxNet;
@@ -18,7 +19,7 @@ public interface ILoxoneStructureState
     IReadOnlyDictionary<string, LoxoneCategory> Categories { get; }
 
     /// <summary>Downloads and parses the <c>LoxApp3.json</c> structure file.</summary>
-    Task LoadAsync();
+    Task LoadAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Retrieves a control by its UUID.</summary>
     bool TryGetControl(string uuid, out LoxoneControl? control);

--- a/LoxNet.Client/Interfaces/ILoxoneWebSocketClient.cs
+++ b/LoxNet.Client/Interfaces/ILoxoneWebSocketClient.cs
@@ -1,16 +1,17 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace LoxNet;
 
 public interface ILoxoneWebSocketClient : IAsyncDisposable
 {
-    Task ConnectAsync();
-    Task CloseAsync();
-    Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user);
-    Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user);
-    Task KeepAliveAsync();
-    Task<LoxoneMessage> CommandAsync(string path);
+    Task ConnectAsync(CancellationToken cancellationToken = default);
+    Task CloseAsync(CancellationToken cancellationToken = default);
+    Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user, CancellationToken cancellationToken = default);
+    Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user, CancellationToken cancellationToken = default);
+    Task KeepAliveAsync(CancellationToken cancellationToken = default);
+    Task<LoxoneMessage> CommandAsync(string path, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Raised when a raw message is received from the websocket.
@@ -20,5 +21,5 @@ public interface ILoxoneWebSocketClient : IAsyncDisposable
     /// <summary>
     /// Starts listening for incoming messages.
     /// </summary>
-    Task ListenAsync(System.Threading.CancellationToken cancellationToken = default);
+    Task ListenAsync(CancellationToken cancellationToken = default);
 }

--- a/LoxNet.Client/LoxoneClient.cs
+++ b/LoxNet.Client/LoxoneClient.cs
@@ -27,7 +27,7 @@ public class LoxoneClient : ILoxoneClient
 
     public async ValueTask DisposeAsync()
     {
-        await Http.DisposeAsync();
-        await WebSocket.DisposeAsync();
+        await Http.DisposeAsync().ConfigureAwait(false);
+        await WebSocket.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/LoxNet.Client/LoxoneStructureState.cs
+++ b/LoxNet.Client/LoxoneStructureState.cs
@@ -46,9 +46,9 @@ public class LoxoneStructureState : ILoxoneStructureState
     public IReadOnlyDictionary<string, LoxoneCategory> Categories => _categoryMap;
     public IReadOnlyDictionary<int, string> GetOperatingModes() => _operatingModes;
 
-    public async Task LoadAsync()
+    public async Task LoadAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _httpClient.RequestJsonAsync("data/LoxApp3.json");
+        using var doc = await _httpClient.RequestJsonAsync("data/LoxApp3.json", cancellationToken).ConfigureAwait(false);
 
         _uuidMap.Clear();
         _roomMap.Clear();

--- a/LoxNet.Client/LoxoneWebSocketClient.cs
+++ b/LoxNet.Client/LoxoneWebSocketClient.cs
@@ -18,33 +18,33 @@ public class LoxoneWebSocketClient : ILoxoneWebSocketClient
         _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }
 
-    public async Task ConnectAsync()
+    public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
         var opts = _http.Options;
         _ws = new ClientWebSocket();
         _ws.Options.AddSubProtocol("remotecontrol");
         string scheme = opts.Secure ? "wss" : "ws";
-        await _ws.ConnectAsync(new Uri($"{scheme}://{opts.Host}:{opts.Port}/ws/rfc6455"), CancellationToken.None);
+        await _ws.ConnectAsync(new Uri($"{scheme}://{opts.Host}:{opts.Port}/ws/rfc6455"), cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task CloseAsync()
+    public async Task CloseAsync(CancellationToken cancellationToken = default)
     {
         if (_ws is not null)
         {
-            await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+            await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, cancellationToken).ConfigureAwait(false);
             _ws.Dispose();
             _ws = null;
         }
     }
 
-    private async Task<string> ReceiveStringAsync()
+    private async Task<string> ReceiveStringAsync(CancellationToken cancellationToken)
     {
         if (_ws is null) throw new InvalidOperationException("WebSocket not connected");
         var buffer = new ArraySegment<byte>(new byte[8192]);
         using var ms = new System.IO.MemoryStream();
         while (true)
         {
-            var result = await _ws.ReceiveAsync(buffer, CancellationToken.None);
+            var result = await _ws.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
             ms.Write(buffer.Array!, buffer.Offset, result.Count);
             if (result.EndOfMessage)
                 break;
@@ -52,53 +52,53 @@ public class LoxoneWebSocketClient : ILoxoneWebSocketClient
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 
-    private async Task SendStringAsync(string text)
+    private async Task SendStringAsync(string text, CancellationToken cancellationToken)
     {
         if (_ws is null) throw new InvalidOperationException("WebSocket not connected");
         var data = Encoding.UTF8.GetBytes(text);
-        await _ws.SendAsync(new ArraySegment<byte>(data), WebSocketMessageType.Text, true, CancellationToken.None);
+        await _ws.SendAsync(new ArraySegment<byte>(data), WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<LoxoneMessage> SendCommandAsync(string command)
+    private async Task<LoxoneMessage> SendCommandAsync(string command, CancellationToken cancellationToken)
     {
-        await SendStringAsync(command);
-        var response = await ReceiveStringAsync();
+        await SendStringAsync(command, cancellationToken).ConfigureAwait(false);
+        var response = await ReceiveStringAsync(cancellationToken).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(response);
         return LoxoneMessageParser.Parse(doc);
     }
 
-    public async Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user)
+    public async Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user, CancellationToken cancellationToken = default)
     {
-        using var doc = await _http.RequestJsonAsync("jdev/sys/getkey");
+        using var doc = await _http.RequestJsonAsync("jdev/sys/getkey", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var key = HexUtils.FromHexString(msg.Value.GetString()!);
         var digest = LoxoneHttpClient.HmacHex(key, Encoding.UTF8.GetBytes(token), System.Security.Cryptography.HashAlgorithmName.SHA1);
-        return await SendCommandAsync($"authwithtoken/{digest}/{user}");
+        return await SendCommandAsync($"authwithtoken/{digest}/{user}", cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user)
+    public async Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user, CancellationToken cancellationToken = default)
     {
-        await ConnectAsync();
+        await ConnectAsync(cancellationToken).ConfigureAwait(false);
         var token = _http.LastToken?.Token ?? throw new InvalidOperationException("No JWT token available");
-        return await AuthenticateWithTokenAsync(token, user);
+        return await AuthenticateWithTokenAsync(token, user, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task ListenAsync(CancellationToken cancellationToken = default)
     {
         while (_ws is not null && _ws.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
         {
-            var msg = await ReceiveStringAsync();
+            var msg = await ReceiveStringAsync(cancellationToken).ConfigureAwait(false);
             MessageReceived?.Invoke(this, msg);
         }
     }
 
-    public async Task KeepAliveAsync() => _ = await SendCommandAsync("keepalive");
+    public async Task KeepAliveAsync(CancellationToken cancellationToken = default) => _ = await SendCommandAsync("keepalive", cancellationToken).ConfigureAwait(false);
 
-    public async Task<LoxoneMessage> CommandAsync(string path) => await SendCommandAsync(path);
+    public async Task<LoxoneMessage> CommandAsync(string path, CancellationToken cancellationToken = default) => await SendCommandAsync(path, cancellationToken).ConfigureAwait(false);
 
     public async ValueTask DisposeAsync()
     {
-        await CloseAsync();
+        await CloseAsync().ConfigureAwait(false);
     }
 }

--- a/LoxNet.Client/Models/LoxoneControl.cs
+++ b/LoxNet.Client/Models/LoxoneControl.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace LoxNet;
 
@@ -113,9 +114,9 @@ public class LoxoneControl
     /// </summary>
     /// <param name="client">HTTP client used to communicate with the Miniserver.</param>
     /// <param name="command">Command path to append after the action UUID.</param>
-    protected async Task<LoxoneMessage> ExecuteCommandAsync(ILoxoneHttpClient client, string command)
+    protected async Task<LoxoneMessage> ExecuteCommandAsync(ILoxoneHttpClient client, string command, CancellationToken cancellationToken = default)
     {
-        using var doc = await client.RequestJsonAsync($"dev/sps/io/{UuidAction}/{command}");
+        using var doc = await client.RequestJsonAsync($"dev/sps/io/{UuidAction}/{command}", cancellationToken).ConfigureAwait(false);
         return LoxoneMessageParser.Parse(doc);
     }
 }

--- a/LoxNet.Client/OperationModes/IOperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/IOperatingModeService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using LoxNet;
 
@@ -10,20 +11,20 @@ namespace LoxNet.OperationModes;
 public interface IOperatingModeService
 {
     /// <summary>Retrieves all schedule entries.</summary>
-    Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync();
+    Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Creates a new schedule entry.</summary>
-    Task CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode);
+    Task CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode, CancellationToken cancellationToken = default);
 
     /// <summary>Updates an existing schedule entry.</summary>
-    Task UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode);
+    Task UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode, CancellationToken cancellationToken = default);
 
     /// <summary>Deletes an entry by its UUID.</summary>
-    Task DeleteEntryAsync(string uuid);
+    Task DeleteEntryAsync(string uuid, CancellationToken cancellationToken = default);
 
     /// <summary>Gets the configured heating period string.</summary>
-    Task<string> GetHeatPeriodAsync();
+    Task<string> GetHeatPeriodAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Gets the configured cooling period string.</summary>
-    Task<string> GetCoolPeriodAsync();
+    Task<string> GetCoolPeriodAsync(CancellationToken cancellationToken = default);
 }

--- a/LoxNet.Client/OperationModes/OperatingModeService.cs
+++ b/LoxNet.Client/OperationModes/OperatingModeService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using LoxNet;
 
@@ -20,9 +21,9 @@ public class OperatingModeService : IOperatingModeService
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync()
+    public async Task<IReadOnlyList<OperatingModeEntry>> GetEntriesAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetentries");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetentries", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var arr = msg.Value;
@@ -36,39 +37,39 @@ public class OperatingModeService : IOperatingModeService
     }
 
     /// <inheritdoc />
-    public async Task CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode)
+    public async Task CreateEntryAsync(string name, string operatingMode, ICalendarModeOption mode, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarcreateentry/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarcreateentry/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode)
+    public async Task UpdateEntryAsync(string uuid, string name, string operatingMode, ICalendarModeOption mode, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarupdateentry/{uuid}/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendarupdateentry/{uuid}/{Uri.EscapeDataString(name)}/{operatingMode}/{(int)mode.Mode}/{Uri.EscapeDataString(mode.ToQueryAttribute())}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task DeleteEntryAsync(string uuid)
+    public async Task DeleteEntryAsync(string uuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendardeleteentry/{uuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/calendardeleteentry/{uuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<string> GetHeatPeriodAsync()
+    public async Task<string> GetHeatPeriodAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetheatperiod");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetheatperiod", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         return msg.Value.GetString()!;
     }
 
     /// <inheritdoc />
-    public async Task<string> GetCoolPeriodAsync()
+    public async Task<string> GetCoolPeriodAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetcoolperiod");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/calendargetcoolperiod", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         return msg.Value.GetString()!;

--- a/LoxNet.Client/Users/IUserService.cs
+++ b/LoxNet.Client/Users/IUserService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
 using LoxNet;
@@ -15,34 +16,34 @@ public interface IUserService
     /// Retrieves a list of configured users.
     /// </summary>
     /// <returns>A collection of <see cref="UserSummary"/> records.</returns>
-    Task<IReadOnlyList<UserSummary>> GetUsersAsync();
+    Task<IReadOnlyList<UserSummary>> GetUsersAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the full configuration for a user.
     /// </summary>
     /// <param name="uuid">The UUID of the user.</param>
     /// <returns>The <see cref="UserDetails"/> for the user.</returns>
-    Task<UserDetails> GetUserAsync(string uuid);
+    Task<UserDetails> GetUserAsync(string uuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the list of available user groups.
     /// </summary>
     /// <returns>A collection of <see cref="UserGroup"/> items.</returns>
-    Task<IReadOnlyList<UserGroup>> GetGroupsAsync();
+    Task<IReadOnlyList<UserGroup>> GetGroupsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new user by username.
     /// </summary>
     /// <param name="username">The name of the new user.</param>
     /// <returns>The UUID of the created user.</returns>
-    Task<string> CreateUserAsync(string username);
+    Task<string> CreateUserAsync(string username, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a user.
     /// </summary>
     /// <param name="uuid">The UUID of the user to delete.</param>
     /// <returns>A task that completes when the user is removed.</returns>
-    Task DeleteUserAsync(string uuid);
+    Task DeleteUserAsync(string uuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a user to a group.
@@ -50,7 +51,7 @@ public interface IUserService
     /// <param name="userUuid">The user's UUID.</param>
     /// <param name="groupUuid">The group's UUID.</param>
     /// <returns>A task that completes when the assignment is done.</returns>
-    Task AssignUserToGroupAsync(string userUuid, string groupUuid);
+    Task AssignUserToGroupAsync(string userUuid, string groupUuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes a user from a group.
@@ -58,27 +59,27 @@ public interface IUserService
     /// <param name="userUuid">The user's UUID.</param>
     /// <param name="groupUuid">The group's UUID.</param>
     /// <returns>A task that completes when the user is removed.</returns>
-    Task RemoveUserFromGroupAsync(string userUuid, string groupUuid);
+    Task RemoveUserFromGroupAsync(string userUuid, string groupUuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the labels for configurable custom user fields.
     /// </summary>
     /// <returns>An ordered list of field labels.</returns>
-    Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync();
+    Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a new user using the provided configuration.
     /// </summary>
     /// <param name="user">The configuration of the user to create.</param>
     /// <returns>The created <see cref="UserDetails"/> returned by the server.</returns>
-    Task<UserDetails> AddUserAsync(AddUser user);
+    Task<UserDetails> AddUserAsync(AddUser user, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates an existing user using the provided configuration.
     /// </summary>
     /// <param name="user">The configuration of the user to edit.</param>
     /// <returns>The updated <see cref="UserDetails"/> returned by the server.</returns>
-    Task<UserDetails> EditUserAsync(EditUser user);
+    Task<UserDetails> EditUserAsync(EditUser user, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the hashed password of a user.
@@ -86,7 +87,7 @@ public interface IUserService
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="hash">The new hashed password value.</param>
     /// <returns>A task that completes when the password is updated.</returns>
-    Task UpdateUserPasswordHashAsync(string uuid, string hash);
+    Task UpdateUserPasswordHashAsync(string uuid, string hash, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the hashed visualization password of a user.
@@ -94,7 +95,7 @@ public interface IUserService
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="hash">The new hashed visu password.</param>
     /// <returns>A task that completes when the password is updated.</returns>
-    Task UpdateUserVisuPasswordHashAsync(string uuid, string hash);
+    Task UpdateUserVisuPasswordHashAsync(string uuid, string hash, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates the access code of a user.
@@ -102,7 +103,7 @@ public interface IUserService
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="accessCode">The new numeric access code.</param>
     /// <returns>A task that completes when the code is updated.</returns>
-    Task UpdateUserAccessCodeAsync(string uuid, string accessCode);
+    Task UpdateUserAccessCodeAsync(string uuid, string accessCode, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Links an NFC tag with a user.
@@ -111,7 +112,7 @@ public interface IUserService
     /// <param name="nfcTagId">The tag identifier.</param>
     /// <param name="name">The label of the tag.</param>
     /// <returns>A task that completes when the tag is added.</returns>
-    Task AddUserNfcTagAsync(string uuid, string nfcTagId, string name);
+    Task AddUserNfcTagAsync(string uuid, string nfcTagId, string name, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes an NFC tag from a user.
@@ -119,40 +120,40 @@ public interface IUserService
     /// <param name="uuid">The UUID of the user.</param>
     /// <param name="nfcTagId">The tag identifier.</param>
     /// <returns>A task that completes when the tag is removed.</returns>
-    Task RemoveUserNfcTagAsync(string uuid, string nfcTagId);
+    Task RemoveUserNfcTagAsync(string uuid, string nfcTagId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves permissions assigned directly to a control.
     /// </summary>
     /// <param name="uuid">The control UUID.</param>
     /// <returns>The raw permissions document returned by the server.</returns>
-    Task<JsonDocument> GetControlPermissionsAsync(string uuid);
+    Task<JsonDocument> GetControlPermissionsAsync(string uuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all configured values for user properties.
     /// </summary>
     /// <returns>Dictionary of property name to configured values.</returns>
-    Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync();
+    Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Looks up a user by the configured user ID.
     /// </summary>
     /// <param name="userId">The user ID to search for.</param>
     /// <returns>The matching user or <c>null</c> if not found.</returns>
-    Task<UserLookup?> CheckUserIdAsync(string userId);
+    Task<UserLookup?> CheckUserIdAsync(string userId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the list of peers available for trust user management.
     /// </summary>
     /// <returns>List of peers.</returns>
-    Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync();
+    Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Discovers users of a peer.
     /// </summary>
     /// <param name="peerSerial">The serial of the peer.</param>
     /// <returns>The discovery result.</returns>
-    Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial);
+    Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a user from a peer via trust management.
@@ -160,7 +161,7 @@ public interface IUserService
     /// <param name="peerSerial">The peer serial.</param>
     /// <param name="userUuid">UUID of the user to add.</param>
     /// <returns>A task that completes when the user is added.</returns>
-    Task TrustAddUserAsync(string peerSerial, string userUuid);
+    Task TrustAddUserAsync(string peerSerial, string userUuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes a user from a peer via trust management.
@@ -168,12 +169,12 @@ public interface IUserService
     /// <param name="peerSerial">The peer serial.</param>
     /// <param name="userUuid">UUID of the user to remove.</param>
     /// <returns>A task that completes when the user is removed.</returns>
-    Task TrustRemoveUserAsync(string peerSerial, string userUuid);
+    Task TrustRemoveUserAsync(string peerSerial, string userUuid, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Applies a trust user edit payload.
     /// </summary>
     /// <param name="json">The JSON body describing the changes.</param>
     /// <returns>A task that completes when the edit is applied.</returns>
-    Task TrustEditAsync(string json);
+    Task TrustEditAsync(string json, CancellationToken cancellationToken = default);
 }

--- a/LoxNet.Client/Users/UserService.cs
+++ b/LoxNet.Client/Users/UserService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using LoxNet;
@@ -21,9 +22,9 @@ public class UserService : IUserService
 
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<UserSummary>> GetUsersAsync()
+    public async Task<IReadOnlyList<UserSummary>> GetUsersAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/getuserlist2");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getuserlist2", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var arr = msg.Value;
@@ -31,9 +32,9 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<UserDetails> GetUserAsync(string uuid)
+    public async Task<UserDetails> GetUserAsync(string uuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/getuser/{uuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/getuser/{uuid}", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var value = msg.Value;
@@ -41,9 +42,9 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<UserGroup>> GetGroupsAsync()
+    public async Task<IReadOnlyList<UserGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/getgrouplist");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getgrouplist", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var arr = msg.Value;
@@ -51,39 +52,39 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<string> CreateUserAsync(string username)
+    public async Task<string> CreateUserAsync(string username, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/createuser/{Uri.EscapeDataString(username)}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/createuser/{Uri.EscapeDataString(username)}", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         return msg.Value.GetString()!;
     }
 
     /// <inheritdoc />
-    public async Task DeleteUserAsync(string uuid)
+    public async Task DeleteUserAsync(string uuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/deleteuser/{uuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/deleteuser/{uuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task AssignUserToGroupAsync(string userUuid, string groupUuid)
+    public async Task AssignUserToGroupAsync(string userUuid, string groupUuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/assignusertogroup/{userUuid}/{groupUuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/assignusertogroup/{userUuid}/{groupUuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task RemoveUserFromGroupAsync(string userUuid, string groupUuid)
+    public async Task RemoveUserFromGroupAsync(string userUuid, string groupUuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/removeuserfromgroup/{userUuid}/{groupUuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/removeuserfromgroup/{userUuid}/{groupUuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync()
+    public async Task<IReadOnlyList<string>> GetCustomFieldLabelsAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/getcustomuserfields");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getcustomuserfields", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var obj = msg.Value;
@@ -94,15 +95,15 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public Task<UserDetails> AddUserAsync(AddUser user) => SendAddOrEditAsync(user);
+    public Task<UserDetails> AddUserAsync(AddUser user, CancellationToken cancellationToken = default) => SendAddOrEditAsync(user, cancellationToken);
 
     /// <inheritdoc />
-    public Task<UserDetails> EditUserAsync(EditUser user) => SendAddOrEditAsync(user);
+    public Task<UserDetails> EditUserAsync(EditUser user, CancellationToken cancellationToken = default) => SendAddOrEditAsync(user, cancellationToken);
 
-    private async Task<UserDetails> SendAddOrEditAsync(AddUser user)
+    private async Task<UserDetails> SendAddOrEditAsync(AddUser user, CancellationToken cancellationToken = default)
     {
         var json = JsonSerializer.Serialize(user);
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/addoredituser/{Uri.EscapeDataString(json)}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/addoredituser/{Uri.EscapeDataString(json)}", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var value = msg.Value;
@@ -110,52 +111,52 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task UpdateUserPasswordHashAsync(string uuid, string hash)
+    public async Task UpdateUserPasswordHashAsync(string uuid, string hash, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuserpwdh/{uuid}/{hash}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuserpwdh/{uuid}/{hash}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task UpdateUserVisuPasswordHashAsync(string uuid, string hash)
+    public async Task UpdateUserVisuPasswordHashAsync(string uuid, string hash, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuservisupwdh/{uuid}/{hash}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuservisupwdh/{uuid}/{hash}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task UpdateUserAccessCodeAsync(string uuid, string accessCode)
+    public async Task UpdateUserAccessCodeAsync(string uuid, string accessCode, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuseraccesscode/{uuid}/{accessCode}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/updateuseraccesscode/{uuid}/{accessCode}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task AddUserNfcTagAsync(string uuid, string nfcTagId, string name)
+    public async Task AddUserNfcTagAsync(string uuid, string nfcTagId, string name, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/addusernfc/{uuid}/{nfcTagId}/{Uri.EscapeDataString(name)}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/addusernfc/{uuid}/{nfcTagId}/{Uri.EscapeDataString(name)}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task RemoveUserNfcTagAsync(string uuid, string nfcTagId)
+    public async Task RemoveUserNfcTagAsync(string uuid, string nfcTagId, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/removeusernfc/{uuid}/{nfcTagId}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/removeusernfc/{uuid}/{nfcTagId}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task<JsonDocument> GetControlPermissionsAsync(string uuid)
+    public async Task<JsonDocument> GetControlPermissionsAsync(string uuid, CancellationToken cancellationToken = default)
     {
-        var doc = await _client.RequestJsonAsync($"jdev/sps/getcontrolpermissions/{uuid}");
+        var doc = await _client.RequestJsonAsync($"jdev/sps/getcontrolpermissions/{uuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
         return doc;
     }
 
     /// <inheritdoc />
-    public async Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync()
+    public async Task<Dictionary<string, string[]>> GetUserPropertyOptionsAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/getuserpropertyoptions");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/getuserpropertyoptions", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var obj = msg.Value;
@@ -169,9 +170,9 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<UserLookup?> CheckUserIdAsync(string userId)
+    public async Task<UserLookup?> CheckUserIdAsync(string userId, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/checkuserid/{Uri.EscapeDataString(userId)}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/checkuserid/{Uri.EscapeDataString(userId)}", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var value = msg.Value;
@@ -183,9 +184,9 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync()
+    public async Task<IReadOnlyList<TrustPeer>> GetTrustPeersAsync(CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync("jdev/sps/trustusermanagement/peers");
+        using var doc = await _client.RequestJsonAsync("jdev/sps/trustusermanagement/peers", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var arr = msg.Value.GetProperty("peers");
@@ -193,9 +194,9 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial)
+    public async Task<TrustDiscoveryResult> DiscoverTrustUsersAsync(string peerSerial, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/discover/{peerSerial}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/discover/{peerSerial}", cancellationToken).ConfigureAwait(false);
         var msg = LoxoneMessageParser.Parse(doc);
         msg.EnsureSuccess();
         var value = msg.Value;
@@ -203,23 +204,23 @@ public class UserService : IUserService
     }
 
     /// <inheritdoc />
-    public async Task TrustAddUserAsync(string peerSerial, string userUuid)
+    public async Task TrustAddUserAsync(string peerSerial, string userUuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/add/{peerSerial}/{userUuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/add/{peerSerial}/{userUuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task TrustRemoveUserAsync(string peerSerial, string userUuid)
+    public async Task TrustRemoveUserAsync(string peerSerial, string userUuid, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/remove/{peerSerial}/{userUuid}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/remove/{peerSerial}/{userUuid}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 
     /// <inheritdoc />
-    public async Task TrustEditAsync(string json)
+    public async Task TrustEditAsync(string json, CancellationToken cancellationToken = default)
     {
-        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/edit/{Uri.EscapeDataString(json)}");
+        using var doc = await _client.RequestJsonAsync($"jdev/sps/trustusermanagement/edit/{Uri.EscapeDataString(json)}", cancellationToken).ConfigureAwait(false);
         LoxoneMessageParser.Parse(doc).EnsureSuccess();
     }
 

--- a/LoxNet.Tests/OperatingModeServiceTests.cs
+++ b/LoxNet.Tests/OperatingModeServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using LoxNet;
@@ -20,7 +21,7 @@ public class OperatingModeServiceTests
         private const string HeatJson = "{\"LL\": { \"Code\": 200, \"value\": \"10-15/04-15\" } }";
         private const string CoolJson = "{\"LL\": { \"Code\": 200, \"value\": \"06-01/09-30\" } }";
 
-        public Task<JsonDocument> RequestJsonAsync(string path)
+        public Task<JsonDocument> RequestJsonAsync(string path, CancellationToken cancellationToken = default)
         {
             Paths.Add(path);
             var json = path switch
@@ -36,8 +37,8 @@ public class OperatingModeServiceTests
             return Task.FromResult(JsonDocument.Parse(json));
         }
 
-        public Task<KeyInfo> GetKey2Async(string user) => throw new System.NotImplementedException();
-        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info) => throw new System.NotImplementedException();
+        public Task<KeyInfo> GetKey2Async(string user, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 

--- a/LoxNet.Tests/StructureCacheTests.cs
+++ b/LoxNet.Tests/StructureCacheTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using LoxNet;
@@ -63,13 +64,13 @@ public class StructureCacheTests
     private class MockWebSocketClient : ILoxoneWebSocketClient
     {
         public event EventHandler<string>? MessageReceived;
-        public Task ConnectAsync() => Task.CompletedTask;
-        public Task CloseAsync() => Task.CompletedTask;
-        public Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user) => Task.FromResult(new LoxoneMessage(0, default, null));
-        public Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user) => Task.FromResult(new LoxoneMessage(0, default, null));
-        public Task KeepAliveAsync() => Task.CompletedTask;
-        public Task<LoxoneMessage> CommandAsync(string path) => Task.FromResult(new LoxoneMessage(0, default, null));
-        public Task ListenAsync(System.Threading.CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task ConnectAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CloseAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<LoxoneMessage> AuthenticateWithTokenAsync(string token, string user, CancellationToken cancellationToken = default) => Task.FromResult(new LoxoneMessage(0, default, null));
+        public Task<LoxoneMessage> ConnectAndAuthenticateAsync(string user, CancellationToken cancellationToken = default) => Task.FromResult(new LoxoneMessage(0, default, null));
+        public Task KeepAliveAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<LoxoneMessage> CommandAsync(string path, CancellationToken cancellationToken = default) => Task.FromResult(new LoxoneMessage(0, default, null));
+        public Task ListenAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public void Send(string json) => MessageReceived?.Invoke(this, json);
@@ -80,9 +81,9 @@ public class StructureCacheTests
         private readonly JsonDocument _doc = JsonDocument.Parse(SampleJson);
         public LoxoneConnectionOptions Options => new("localhost", 0, false);
         public TokenInfo? LastToken => null;
-        public Task<JsonDocument> RequestJsonAsync(string path) => Task.FromResult(_doc);
-        public Task<KeyInfo> GetKey2Async(string user) => throw new NotImplementedException();
-        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info) => throw new NotImplementedException();
+        public Task<JsonDocument> RequestJsonAsync(string path, CancellationToken cancellationToken = default) => Task.FromResult(_doc);
+        public Task<KeyInfo> GetKey2Async(string user, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 

--- a/LoxNet.Tests/UserServiceTests.cs
+++ b/LoxNet.Tests/UserServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using LoxNet;
@@ -27,7 +28,7 @@ public class UserServiceTests
         private const string DiscoverJson = "{\"LL\":{\"Code\":200,\"value\":{\"serial\":\"p1\",\"users\":[{\"name\":\"u\",\"uuid\":\"1\",\"used\":false}]}}}";
         private const string PermJson = "{\"LL\":{\"Code\":200,\"value\":{}}}";
 
-        public Task<JsonDocument> RequestJsonAsync(string path)
+        public Task<JsonDocument> RequestJsonAsync(string path, CancellationToken cancellationToken = default)
         {
             Paths.Add(path);
             var json = path switch
@@ -59,8 +60,8 @@ public class UserServiceTests
             return Task.FromResult(JsonDocument.Parse(json));
         }
 
-        public Task<KeyInfo> GetKey2Async(string user) => throw new System.NotImplementedException();
-        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info) => throw new System.NotImplementedException();
+        public Task<KeyInfo> GetKey2Async(string user, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
+        public Task<TokenInfo> GetJwtAsync(string user, string password, int permission, string info, CancellationToken cancellationToken = default) => throw new System.NotImplementedException();
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary
- pass CancellationToken parameters through the library
- use ConfigureAwait(false) on all awaits
- update unit test mocks for new method signatures
- document new async guidelines
- simplify CancellationToken usage with `using System.Threading`

## Testing
- `dotnet test LoxNet.Tests/LoxNet.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_686ecfaffce8832689f23f431476f321