### PR TITLE
Add Zigbee2MQTT bridge service

### DIFF
--- a/LoxNet.Bridge/Dockerfile
+++ b/LoxNet.Bridge/Dockerfile
@@ -1,0 +1,14 @@
+# build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY LoxNet.Client ./LoxNet.Client
+COPY LoxNet.Bridge ./LoxNet.Bridge
+RUN dotnet restore LoxNet.Bridge/src/Bridge/Bridge.csproj
+RUN dotnet publish LoxNet.Bridge/src/Bridge/Bridge.csproj -c Release -o /app/publish
+
+# runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish ./
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Bridge.dll"]

--- a/LoxNet.Bridge/README.md
+++ b/LoxNet.Bridge/README.md
@@ -23,6 +23,67 @@ A lightweight service that bridges Zigbee2MQTT devices with Loxone LightControll
 * Commands are published to `<device>/set` automatically.
 * The bridge publishes minimal MQTT payloads so devices only receive fields that change.
 
+## Configuration examples
+
+### Dimmer mapping
+
+```yaml
+loxone:
+  host: "192.168.1.10"
+  user: "bridge"
+  password: "secret"
+
+mqtt:
+  host: "mqtt"
+
+mappings:
+  - name: "Kitchen spots"
+    kind: "dimmer"
+    mqttTopic: "zigbee2mqtt/kitchen_spots"
+    loxoneUuidAction: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    options:
+      preferMqttState: true
+```
+
+### ColorPickerV2 mapping
+
+```yaml
+loxone:
+  host: "192.168.1.10"
+  user: "bridge"
+  password: "secret"
+
+mqtt:
+  host: "mqtt"
+
+mappings:
+  - name: "Kitchen strip"
+    kind: "colorpickerv2"
+    mqttTopic: "zigbee2mqtt/kitchen_strip"
+    loxoneUuidAction: "ffffffff-1111-2222-3333-444444444444"
+    options:
+      allowColor: true
+      preferMqttState: true
+```
+
+### MQTT payloads sent by the bridge
+
+```json
+{ "state": "ON" }
+```
+
+```json
+{ "brightness": 127 }
+```
+
+```json
+{ "color_temp": 250 }
+```
+
+```json
+{ "color": { "h": 120, "s": 100, "v": 75 } }
+```
+
 ## Troubleshooting
 
 * `GET /health` returns overall status plus per-mapping errors such as missing subcontrols or type mismatches.

--- a/LoxNet.Bridge/README.md
+++ b/LoxNet.Bridge/README.md
@@ -1,0 +1,30 @@
+# LoxNet Zigbee2MQTT Bridge
+
+A lightweight service that bridges Zigbee2MQTT devices with Loxone LightControllerV2 subcontrols using the LoxNet client library. It keeps dimmer and ColorPickerV2 subcontrols in sync without implementing moods or modifying Loxone configuration.
+
+## Running with Docker Compose
+
+1. Build and start the stack:
+   ```sh
+   docker compose -f docker-compose.example.yml up --build
+   ```
+2. Place your configuration file at `./data/config.yaml` or set `CONFIG` to another path.
+3. Browse `http://localhost:8080/health` to confirm connectivity and mapping status.
+
+## Discovering Loxone subcontrols
+
+1. Run the bridge.
+2. Call `GET /discover/loxone/subcontrols` on port `8080`.
+3. Locate subcontrols of type `Dimmer` or `ColorPickerV2` and copy their `uuidAction` values for your mappings.
+
+## Mapping Zigbee2MQTT devices
+
+* Use device topics in the form `zigbee2mqtt/<device>`.
+* Commands are published to `<device>/set` automatically.
+* The bridge publishes minimal MQTT payloads so devices only receive fields that change.
+
+## Troubleshooting
+
+* `GET /health` returns overall status plus per-mapping errors such as missing subcontrols or type mismatches.
+* Ensure `loxoneUuidAction` and `kind` match the actual subcontrol type in the Loxone structure file.
+* Verify MQTT credentials and connectivity if `/health` reports `mqtt: disconnected`.

--- a/LoxNet.Bridge/docker-compose.example.yml
+++ b/LoxNet.Bridge/docker-compose.example.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  loxnet-bridge:
+    build: .
+    image: loxnet-bridge:latest
+    environment:
+      - CONFIG=/data/config.yaml
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/data
+    depends_on:
+      - mqtt
+  mqtt:
+    image: eclipse-mosquitto:2
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf

--- a/LoxNet.Bridge/src/Bridge/Api/MinimalApiHost.cs
+++ b/LoxNet.Bridge/src/Bridge/Api/MinimalApiHost.cs
@@ -1,0 +1,124 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Mqtt;
+using LoxNet.Bridge.Sync;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using LoxNet;
+
+namespace LoxNet.Bridge.Api;
+
+public class MinimalApiHost : IHostedService
+{
+    private readonly BridgeConfig _config;
+    private readonly MqttService _mqttService;
+    private readonly LoxoneService _loxoneService;
+    private IHost? _webHost;
+
+    public MinimalApiHost(BridgeConfig config, MqttService mqttService, LoxoneService loxoneService)
+    {
+        _config = config;
+        _mqttService = mqttService;
+        _loxoneService = loxoneService;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            ApplicationName = typeof(MinimalApiHost).Assembly.FullName,
+            Args = Array.Empty<string>()
+        });
+
+        builder.Logging.ClearProviders();
+        builder.Logging.AddConsole();
+
+        var app = builder.Build();
+
+        app.MapGet("/health", () => BuildHealth());
+        app.MapGet("/discover/loxone/subcontrols", () => DiscoverLoxoneSubcontrols());
+        app.MapGet("/discover/mqtt/devices", () => new { devices = Array.Empty<string>(), hint = "Subscribe to zigbee2mqtt/bridge/devices for details" });
+
+        _webHost = app;
+        await app.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_webHost is not null)
+        {
+            await _webHost.StopAsync(cancellationToken).ConfigureAwait(false);
+            await _webHost.WaitForShutdownAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private object BuildHealth()
+    {
+        var mqttStatus = _mqttService.Client.IsConnected ? "connected" : "disconnected";
+        var loxoneStatus = _loxoneService.Client is not null ? "connected" : "disconnected";
+        var mappings = new List<object>();
+        var degraded = false;
+        foreach (var mapping in _config.Mappings)
+        {
+            var status = "ok";
+            if (_loxoneService.Structure is null || !_loxoneService.Structure.TryGetControl(mapping.LoxoneUuidAction, out var control) || control is null)
+            {
+                status = "missing_subcontrol";
+            }
+            else if (!MatchesKind(control.Type, mapping.Kind))
+            {
+                status = "type_mismatch";
+            }
+
+            degraded |= status != "ok";
+
+            mappings.Add(new
+            {
+                mapping.Name,
+                mapping.Kind,
+                mapping.MqttTopic,
+                mapping.LoxoneUuidAction,
+                status
+            });
+        }
+
+        var bridgeStatus = degraded ? "degraded" : "ok";
+        return new
+        {
+            status = bridgeStatus,
+            mqtt = mqttStatus,
+            loxone = loxoneStatus,
+            mappings
+        };
+    }
+
+    private IEnumerable<object> DiscoverLoxoneSubcontrols()
+    {
+        if (_loxoneService.Structure is null)
+        {
+            return Array.Empty<object>();
+        }
+
+        return _loxoneService.Structure.Controls.Values
+            .Where(c => c.Type is ControlType.Dimmer or ControlType.ColorPickerV2)
+            .Select(c => new
+            {
+                parentName = c.RoomName ?? string.Empty,
+                subcontrolName = c.Name,
+                type = c.Type.ToString(),
+                uuidAction = c.UuidAction ?? c.Uuid
+            })
+            .DistinctBy(c => c.uuidAction);
+    }
+
+    private static bool MatchesKind(ControlType type, string kind)
+    {
+        return kind.ToLowerInvariant() switch
+        {
+            "dimmer" => type == ControlType.Dimmer,
+            "colorpickerv2" => type == ControlType.ColorPickerV2,
+            _ => false
+        };
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/AppHost.cs
+++ b/LoxNet.Bridge/src/Bridge/AppHost.cs
@@ -1,0 +1,50 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Mqtt;
+using LoxNet.Bridge.Sync;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace LoxNet.Bridge;
+
+public class AppHost : IHostedService
+{
+    private readonly BridgeConfig _config;
+    private readonly MqttService _mqttService;
+    private readonly LoxoneService _loxoneService;
+    private readonly SyncEngine _syncEngine;
+    private readonly ILogger<AppHost> _logger;
+
+    public AppHost(BridgeConfig config, MqttService mqttService, LoxoneService loxoneService, SyncEngine syncEngine, ILogger<AppHost> logger)
+    {
+        _config = config;
+        _mqttService = mqttService;
+        _loxoneService = loxoneService;
+        _syncEngine = syncEngine;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting bridge with {MappingCount} mappings", _config.Mappings.Count);
+
+        await _mqttService.StartAsync(_config, HandleMqttMessageAsync, cancellationToken).ConfigureAwait(false);
+        await _loxoneService.StartAsync(_config, HandleLoxoneStateAsync, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _mqttService.StopAsync(cancellationToken).ConfigureAwait(false);
+        await _loxoneService.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private Task HandleMqttMessageAsync(string topic, NormalizedLightState state, CancellationToken cancellationToken)
+    {
+        return _syncEngine.ProcessMqttAsync(topic, state, cancellationToken);
+    }
+
+    private Task HandleLoxoneStateAsync(string uuidAction, NormalizedLightState state, CancellationToken cancellationToken)
+    {
+        return _syncEngine.ProcessLoxoneAsync(uuidAction, state, cancellationToken);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Bridge.csproj
+++ b/LoxNet.Bridge/src/Bridge/Bridge.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LoxNet.Bridge</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MQTTnet" Version="4.3.13.992" />
+    <PackageReference Include="YamlDotNet" Version="15.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../LoxNet.Client/LoxNet.Client.csproj" />
+  </ItemGroup>
+</Project>

--- a/LoxNet.Bridge/src/Bridge/Config/BridgeConfig.cs
+++ b/LoxNet.Bridge/src/Bridge/Config/BridgeConfig.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LoxNet.Bridge.Config;
+
+public class BridgeConfig
+{
+    public LoxoneSection Loxone { get; init; } = new();
+
+    public MqttSection Mqtt { get; init; } = new();
+
+    public SyncSection Sync { get; init; } = new();
+
+    public IReadOnlyList<MappingSection> Mappings { get; init; } = Array.Empty<MappingSection>();
+
+    public void Validate()
+    {
+        Validator.ValidateObject(Loxone, new ValidationContext(Loxone), true);
+        Validator.ValidateObject(Mqtt, new ValidationContext(Mqtt), true);
+        Validator.ValidateObject(Sync, new ValidationContext(Sync), true);
+
+        foreach (var mapping in Mappings)
+        {
+            Validator.ValidateObject(mapping, new ValidationContext(mapping), true);
+        }
+
+        var duplicateUuid = Mappings
+            .GroupBy(m => m.LoxoneUuidAction, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(duplicateUuid))
+        {
+            throw new ValidationException($"Duplicate loxoneUuidAction detected: {duplicateUuid}");
+        }
+
+        var duplicateTopic = Mappings
+            .GroupBy(m => m.MqttTopic, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(duplicateTopic))
+        {
+            throw new ValidationException($"Duplicate mqttTopic detected: {duplicateTopic}");
+        }
+    }
+}
+
+public class LoxoneSection
+{
+    [Required]
+    public string Host { get; init; } = string.Empty;
+
+    public int Port { get; init; } = 80;
+
+    public bool UseHttps { get; init; }
+
+    [Required]
+    public string User { get; init; } = string.Empty;
+
+    [Required]
+    public string Password { get; init; } = string.Empty;
+
+    public string? Loxapp3Path { get; init; }
+
+    public bool RefreshLoxapp3OnStart { get; init; } = true;
+}
+
+public class MqttSection
+{
+    [Required]
+    public string Host { get; init; } = string.Empty;
+
+    public int Port { get; init; } = 1883;
+
+    public string? Username { get; init; }
+
+    public string? Password { get; init; }
+
+    public string ClientId { get; init; } = "loxone-z2m-bridge";
+
+    public string BaseTopic { get; init; } = "zigbee2mqtt";
+}
+
+public class SyncSection
+{
+    public int BrightnessTolerancePct { get; init; } = 1;
+
+    public int KelvinTolerance { get; init; } = 25;
+
+    public int SuppressEchoWindowMs { get; init; }
+}
+
+public class MappingSection
+{
+    [Required]
+    public string Name { get; init; } = string.Empty;
+
+    [Required]
+    public string Kind { get; init; } = string.Empty;
+
+    [Required]
+    public string MqttTopic { get; init; } = string.Empty;
+
+    [Required]
+    public string LoxoneUuidAction { get; init; } = string.Empty;
+
+    public MappingOptions Options { get; init; } = new();
+}
+
+public class MappingOptions
+{
+    public bool PreferMqttState { get; init; }
+
+    public bool AllowColor { get; init; } = true;
+}

--- a/LoxNet.Bridge/src/Bridge/Config/ConfigLoader.cs
+++ b/LoxNet.Bridge/src/Bridge/Config/ConfigLoader.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Configuration;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace LoxNet.Bridge.Config;
+
+public static class ConfigLoader
+{
+    public static async Task<BridgeConfig> LoadAsync(IConfiguration configuration, string? configPathFromEnv)
+    {
+        var path = configPathFromEnv;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = configuration["CONFIG"];
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = "/data/config.yaml";
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Config file not found at {path}");
+        }
+
+        await using var stream = File.OpenRead(path);
+        using var reader = new StreamReader(stream);
+        var yaml = await reader.ReadToEndAsync().ConfigureAwait(false);
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var config = deserializer.Deserialize<BridgeConfig>(yaml) ?? new BridgeConfig();
+        config.Validate();
+        return config;
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Logging/LoggingSetup.cs
+++ b/LoxNet.Bridge/src/Bridge/Logging/LoggingSetup.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+
+namespace LoxNet.Bridge.Logging;
+
+public static class LoggingSetup
+{
+    public static void Configure(ILoggingBuilder builder)
+    {
+        builder.ClearProviders();
+        builder.AddSimpleConsole(options =>
+        {
+            options.TimestampFormat = "yyyy-MM-dd HH:mm:ss ";
+            options.SingleLine = true;
+        });
+        builder.SetMinimumLevel(LogLevel.Information);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Loxone/ILoxoneCommandExecutor.cs
+++ b/LoxNet.Bridge/src/Bridge/Loxone/ILoxoneCommandExecutor.cs
@@ -1,0 +1,8 @@
+using LoxNet.Bridge.Config;
+
+namespace LoxNet.Bridge.Loxone;
+
+public interface ILoxoneCommandExecutor
+{
+    Task SendCommandsAsync(MappingSection mapping, IEnumerable<string> commands, CancellationToken cancellationToken);
+}

--- a/LoxNet.Bridge/src/Bridge/Loxone/LoxoneCommandBuilder.cs
+++ b/LoxNet.Bridge/src/Bridge/Loxone/LoxoneCommandBuilder.cs
@@ -1,0 +1,44 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Sync;
+
+namespace LoxNet.Bridge.Loxone;
+
+public class LoxoneCommandBuilder
+{
+    public IReadOnlyList<string> BuildCommands(MappingSection mapping, NormalizedLightState state)
+    {
+        var commands = new List<string>();
+        var kind = mapping.Kind.ToLowerInvariant();
+        if (kind == "dimmer")
+        {
+            if (state.Power.HasValue)
+            {
+                commands.Add(state.Power.Value ? "on" : "off");
+            }
+
+            if (state.BrightnessPct.HasValue)
+            {
+                commands.Add(state.BrightnessPct.Value.ToString());
+            }
+        }
+        else if (kind == "colorpickerv2")
+        {
+            if (state.Kelvin.HasValue && state.BrightnessPct.HasValue)
+            {
+                commands.Add($"temp({state.BrightnessPct.Value},{state.Kelvin.Value})");
+            }
+            else if (state.BrightnessPct.HasValue)
+            {
+                commands.Add($"setBrightness/{state.BrightnessPct.Value}");
+            }
+
+            if (state.Hsv.HasValue && mapping.Options.AllowColor)
+            {
+                var hsv = state.Hsv.Value;
+                commands.Add($"hsv({hsv.H},{hsv.S},{hsv.V})");
+            }
+        }
+
+        return commands;
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Loxone/LoxoneService.cs
+++ b/LoxNet.Bridge/src/Bridge/Loxone/LoxoneService.cs
@@ -1,0 +1,105 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Sync;
+using Microsoft.Extensions.Logging;
+using LoxNet;
+
+namespace LoxNet.Bridge.Loxone;
+
+public class LoxoneService : ILoxoneCommandExecutor
+{
+    private readonly ILogger<LoxoneService> _logger;
+    private readonly LoxoneStateParser _stateParser;
+    private LoxoneClient? _client;
+    private LoxoneStructureState? _structure;
+    private Func<string, NormalizedLightState, CancellationToken, Task>? _callback;
+
+    public LoxoneService(ILogger<LoxoneService> logger, LoxoneStateParser stateParser)
+    {
+        _logger = logger;
+        _stateParser = stateParser;
+    }
+
+    public LoxoneClient? Client => _client;
+
+    public LoxoneStructureState? Structure => _structure;
+
+    public async Task StartAsync(BridgeConfig config, Func<string, NormalizedLightState, CancellationToken, Task> callback, CancellationToken cancellationToken)
+    {
+        _callback = callback;
+        _client = new LoxoneClient(new LoxoneConnectionOptions(config.Loxone.Host, config.Loxone.Port, config.Loxone.UseHttps));
+        await _client.LoginAsync(config.Loxone.User, config.Loxone.Password, cancellationToken: cancellationToken).ConfigureAwait(false);
+        _structure = new LoxoneStructureState(_client.Http, wsClient: _client.WebSocket);
+        await _structure.LoadAsync(cancellationToken).ConfigureAwait(false);
+        await SubscribeToMappingsAsync(config, cancellationToken).ConfigureAwait(false);
+        _ = Task.Run(() => _client.WebSocket.ListenAsync(cancellationToken), cancellationToken);
+        await _client.WebSocket.CommandAsync("jdev/sps/enablebinstatusupdate", cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_client is not null)
+        {
+            await _client.WebSocket.CloseAsync(cancellationToken).ConfigureAwait(false);
+            await _client.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    public async Task SendCommandsAsync(MappingSection mapping, IEnumerable<string> commands, CancellationToken cancellationToken)
+    {
+        if (_client is null)
+        {
+            throw new InvalidOperationException("Loxone client not initialized");
+        }
+
+        foreach (var command in commands)
+        {
+            using var doc = await _client.Http.RequestJsonAsync($"dev/sps/io/{mapping.LoxoneUuidAction}/{command}", cancellationToken).ConfigureAwait(false);
+            var msg = LoxoneMessageParser.Parse(doc);
+            msg.EnsureSuccess();
+        }
+    }
+
+    private async Task SubscribeToMappingsAsync(BridgeConfig config, CancellationToken cancellationToken)
+    {
+        if (_structure is null)
+        {
+            return;
+        }
+
+        foreach (var mapping in config.Mappings)
+        {
+            if (!_structure.TryGetControl(mapping.LoxoneUuidAction, out var control) || control is null)
+            {
+                _logger.LogWarning("Mapping {Name} references unknown uuidAction {Uuid}", mapping.Name, mapping.LoxoneUuidAction);
+                continue;
+            }
+
+            control.StateChanged += async (_, args) =>
+            {
+                await HandleStateAsync(mapping, args.Name, args.Value, cancellationToken).ConfigureAwait(false);
+            };
+        }
+    }
+
+    private Task HandleStateAsync(MappingSection mapping, string stateName, string value, CancellationToken cancellationToken)
+    {
+        if (_callback is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var normalized = mapping.Kind.ToLowerInvariant() switch
+        {
+            "dimmer" => _stateParser.FromDimmer(value),
+            "colorpickerv2" => _stateParser.FromColorPicker(value),
+            _ => NormalizedLightState.Empty
+        };
+
+        if (normalized == NormalizedLightState.Empty)
+        {
+            return Task.CompletedTask;
+        }
+
+        return _callback(mapping.LoxoneUuidAction, normalized, cancellationToken);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Loxone/LoxoneStateParser.cs
+++ b/LoxNet.Bridge/src/Bridge/Loxone/LoxoneStateParser.cs
@@ -1,0 +1,56 @@
+using LoxNet.Bridge.Sync;
+using Microsoft.Extensions.Logging;
+
+namespace LoxNet.Bridge.Loxone;
+
+public class LoxoneStateParser
+{
+    private readonly ILogger<LoxoneStateParser> _logger;
+
+    public LoxoneStateParser(ILogger<LoxoneStateParser> logger)
+    {
+        _logger = logger;
+    }
+
+    public NormalizedLightState FromDimmer(string? value)
+    {
+        if (int.TryParse(value, out var pos))
+        {
+            return new NormalizedLightState(pos > 0, pos, null, null);
+        }
+
+        _logger.LogWarning("Unable to parse dimmer state {Value}", value);
+        return NormalizedLightState.Empty;
+    }
+
+    public NormalizedLightState FromColorPicker(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return NormalizedLightState.Empty;
+        }
+
+        if (value.StartsWith("hsv(", StringComparison.OrdinalIgnoreCase) && value.EndsWith(')'))
+        {
+            var content = value[4..^1];
+            var parts = content.Split(',');
+            if (parts.Length == 3 && int.TryParse(parts[0], out var h) && int.TryParse(parts[1], out var s) && int.TryParse(parts[2], out var v))
+            {
+                return new NormalizedLightState(null, null, null, (h, s, v));
+            }
+        }
+
+        if (value.StartsWith("temp(", StringComparison.OrdinalIgnoreCase) && value.EndsWith(')'))
+        {
+            var content = value[5..^1];
+            var parts = content.Split(',');
+            if (parts.Length == 2 && int.TryParse(parts[0], out var brightness) && int.TryParse(parts[1], out var kelvin))
+            {
+                return new NormalizedLightState(null, brightness, kelvin, null);
+            }
+        }
+
+        _logger.LogWarning("Unrecognized color picker state {Value}", value);
+        return NormalizedLightState.Empty;
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Mqtt/IMqttClientHost.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/IMqttClientHost.cs
@@ -1,0 +1,8 @@
+using MQTTnet.Client;
+
+namespace LoxNet.Bridge.Mqtt;
+
+public interface IMqttClientHost
+{
+    IMqttClient Client { get; }
+}

--- a/LoxNet.Bridge/src/Bridge/Mqtt/IMqttPublisher.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/IMqttPublisher.cs
@@ -1,0 +1,11 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Sync;
+
+namespace LoxNet.Bridge.Mqtt;
+
+public interface IMqttPublisher
+{
+    bool IsConnected { get; }
+
+    Task PublishAsync(MappingSection mapping, NormalizedLightState desired, NormalizedLightState lastSent, CancellationToken cancellationToken);
+}

--- a/LoxNet.Bridge/src/Bridge/Mqtt/MqttPublisherAdapter.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/MqttPublisherAdapter.cs
@@ -1,0 +1,24 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Sync;
+using MQTTnet.Client;
+
+namespace LoxNet.Bridge.Mqtt;
+
+public class MqttPublisherAdapter : IMqttPublisher
+{
+    private readonly IMqttClientHost _host;
+    private readonly Z2mPublisher _publisher;
+
+    public MqttPublisherAdapter(IMqttClientHost host, Z2mPublisher publisher)
+    {
+        _host = host;
+        _publisher = publisher;
+    }
+
+    public bool IsConnected => _host.Client.IsConnected;
+
+    public Task PublishAsync(MappingSection mapping, NormalizedLightState desired, NormalizedLightState lastSent, CancellationToken cancellationToken)
+    {
+        return _publisher.PublishAsync(_host.Client, mapping, desired, lastSent, cancellationToken);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Mqtt/MqttService.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/MqttService.cs
@@ -1,0 +1,73 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Sync;
+using Microsoft.Extensions.Logging;
+using MQTTnet;
+using MQTTnet.Client;
+
+namespace LoxNet.Bridge.Mqtt;
+
+public class MqttService : IMqttClientHost
+{
+    private readonly ILogger<MqttService> _logger;
+    private readonly Z2mMessageParser _parser;
+    private readonly IMqttClient _client;
+
+    public MqttService(ILogger<MqttService> logger, Z2mMessageParser parser, IMqttClient? client = null)
+    {
+        _logger = logger;
+        _parser = parser;
+        _client = client ?? new MqttFactory().CreateMqttClient();
+    }
+
+    public IMqttClient Client => _client;
+
+    public async Task StartAsync(BridgeConfig config, Func<string, NormalizedLightState, CancellationToken, Task> handler, CancellationToken cancellationToken)
+    {
+        var mqttOptions = new MqttClientOptionsBuilder()
+            .WithTcpServer(config.Mqtt.Host, config.Mqtt.Port)
+            .WithClientId(config.Mqtt.ClientId)
+            .WithCredentials(config.Mqtt.Username, config.Mqtt.Password)
+            .Build();
+
+        _client.ApplicationMessageReceivedAsync += args =>
+        {
+            var topic = args.ApplicationMessage.Topic;
+            try
+            {
+                var payload = args.ApplicationMessage.PayloadSegment.ToArray();
+                var json = System.Text.Encoding.UTF8.GetString(payload);
+                var state = _parser.Parse(json);
+                return handler(topic, state, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to process MQTT message on {Topic}", topic);
+                return Task.CompletedTask;
+            }
+        };
+
+        _client.ConnectedAsync += _ =>
+        {
+            _logger.LogInformation("Connected to MQTT at {Host}:{Port}", config.Mqtt.Host, config.Mqtt.Port);
+            return SubscribeTopicsAsync(config, cancellationToken);
+        };
+
+        await _client.ConnectAsync(mqttOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_client.IsConnected)
+        {
+            await _client.DisconnectAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private Task SubscribeTopicsAsync(BridgeConfig config, CancellationToken cancellationToken)
+    {
+        var topics = config.Mappings.Select(m => m.MqttTopic).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var options = topics.Select(t => new MqttTopicFilterBuilder().WithTopic(t).Build()).ToList();
+        _logger.LogInformation("Subscribing to {Count} MQTT topics", options.Count);
+        return _client.SubscribeAsync(options, cancellationToken);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Mqtt/Z2mMessageParser.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/Z2mMessageParser.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using LoxNet.Bridge.Sync;
+
+namespace LoxNet.Bridge.Mqtt;
+
+public class Z2mMessageParser
+{
+    private readonly Converters _converters;
+
+    public Z2mMessageParser(Converters converters)
+    {
+        _converters = converters;
+    }
+
+    public NormalizedLightState Parse(string payload)
+    {
+        using var doc = JsonDocument.Parse(payload);
+        var root = doc.RootElement;
+
+        bool? power = null;
+        int? brightnessPct = null;
+        int? kelvin = null;
+        (int H, int S, int V)? hsv = null;
+
+        if (root.TryGetProperty("state", out var stateProp))
+        {
+            var state = stateProp.GetString();
+            power = string.Equals(state, "ON", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (root.TryGetProperty("brightness", out var brightnessProp) && brightnessProp.TryGetInt32(out var brightness))
+        {
+            brightnessPct = _converters.ToBrightnessPercent(brightness);
+        }
+
+        if (root.TryGetProperty("color_temp", out var ctProp) && ctProp.TryGetInt32(out var colorTemp))
+        {
+            kelvin = _converters.ToKelvin(colorTemp);
+        }
+
+        if (root.TryGetProperty("color", out var colorProp))
+        {
+            var h = colorProp.TryGetProperty("h", out var hProp) && hProp.TryGetInt32(out var hVal) ? hVal : (int?)null;
+            var s = colorProp.TryGetProperty("s", out var sProp) && sProp.TryGetInt32(out var sVal) ? sVal : (int?)null;
+            var v = colorProp.TryGetProperty("v", out var vProp) && vProp.TryGetInt32(out var vVal) ? vVal : (int?)null;
+
+            if (h.HasValue && s.HasValue && v.HasValue)
+            {
+                hsv = (h.Value, s.Value, v.Value);
+            }
+        }
+
+        return new NormalizedLightState(power, brightnessPct, kelvin, hsv);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Mqtt/Z2mPublisher.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/Z2mPublisher.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Sync;
+
+namespace LoxNet.Bridge.Mqtt;
+
+public class Z2mPublisher
+{
+    private readonly Converters _converters;
+
+    public Z2mPublisher(Converters converters)
+    {
+        _converters = converters;
+    }
+
+    public MqttApplicationMessage BuildMessage(MappingSection mapping, NormalizedLightState desired, NormalizedLightState lastSent)
+    {
+        var payload = BuildPayload(desired, lastSent);
+        return new MqttApplicationMessageBuilder()
+            .WithTopic($"{mapping.MqttTopic}/set")
+            .WithPayload(payload)
+            .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+            .Build();
+    }
+
+    public string BuildPayload(NormalizedLightState desired, NormalizedLightState lastSent)
+    {
+        using var buffer = new MemoryStream();
+        using var writer = new Utf8JsonWriter(buffer);
+        writer.WriteStartObject();
+
+        if (desired.Power != lastSent.Power && desired.Power.HasValue)
+        {
+            writer.WriteString("state", desired.Power.Value ? "ON" : "OFF");
+        }
+
+        if (desired.BrightnessPct.HasValue && (!lastSent.BrightnessPct.HasValue || desired.BrightnessPct.Value != lastSent.BrightnessPct.Value))
+        {
+            writer.WriteNumber("brightness", _converters.ToMqttBrightness(desired.BrightnessPct.Value));
+        }
+
+        if (desired.Kelvin.HasValue && (!lastSent.Kelvin.HasValue || desired.Kelvin.Value != lastSent.Kelvin.Value))
+        {
+            writer.WriteNumber("color_temp", _converters.ToMired(desired.Kelvin.Value));
+        }
+
+        if (desired.Hsv.HasValue && (!lastSent.Hsv.HasValue || desired.Hsv.Value != lastSent.Hsv.Value))
+        {
+            writer.WritePropertyName("color");
+            writer.WriteStartObject();
+            var hsv = desired.Hsv.Value;
+            writer.WriteNumber("h", hsv.H);
+            writer.WriteNumber("s", hsv.S);
+            writer.WriteNumber("v", hsv.V);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndObject();
+        writer.Flush();
+        return System.Text.Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    public async Task PublishAsync(IMqttClient client, MappingSection mapping, NormalizedLightState desired, NormalizedLightState lastSent, CancellationToken cancellationToken)
+    {
+        var message = BuildMessage(mapping, desired, lastSent);
+        await client.PublishAsync(message, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Program.cs
+++ b/LoxNet.Bridge/src/Bridge/Program.cs
@@ -1,0 +1,32 @@
+using LoxNet.Bridge;
+using LoxNet.Bridge.Api;
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Logging;
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Mqtt;
+using LoxNet.Bridge.Sync;
+
+var builder = Host.CreateApplicationBuilder(args);
+LoggingSetup.Configure(builder.Logging);
+
+var bridgeConfig = await ConfigLoader.LoadAsync(builder.Configuration, builder.Configuration["CONFIG"]);
+builder.Services.AddSingleton(bridgeConfig);
+builder.Services.AddSingleton<StateCache>();
+builder.Services.AddSingleton<StateComparer>();
+builder.Services.AddSingleton<Converters>();
+builder.Services.AddSingleton<Z2mMessageParser>();
+builder.Services.AddSingleton<Z2mPublisher>();
+builder.Services.AddSingleton<LoxoneStateParser>();
+builder.Services.AddSingleton<LoxoneCommandBuilder>();
+builder.Services.AddSingleton<MqttService>();
+builder.Services.AddSingleton<IMqttClientHost>(sp => sp.GetRequiredService<MqttService>());
+builder.Services.AddSingleton<IMqttPublisher>(sp => new MqttPublisherAdapter(sp.GetRequiredService<IMqttClientHost>(), sp.GetRequiredService<Z2mPublisher>()));
+builder.Services.AddSingleton<LoxoneService>();
+builder.Services.AddSingleton<ILoxoneCommandExecutor>(sp => sp.GetRequiredService<LoxoneService>());
+builder.Services.AddSingleton<SyncEngine>();
+builder.Services.AddHostedService<AppHost>();
+builder.Services.AddHostedService<MinimalApiHost>();
+
+var host = builder.Build();
+
+await host.RunAsync();

--- a/LoxNet.Bridge/src/Bridge/Sync/Converters.cs
+++ b/LoxNet.Bridge/src/Bridge/Sync/Converters.cs
@@ -1,0 +1,25 @@
+namespace LoxNet.Bridge.Sync;
+
+public class Converters
+{
+    public int ToBrightnessPercent(int mqttBrightness)
+    {
+        return (int)Math.Round(mqttBrightness / 254.0 * 100);
+    }
+
+    public int ToMqttBrightness(int percent)
+    {
+        var value = (int)Math.Round(percent / 100.0 * 254);
+        return Math.Clamp(value, 0, 254);
+    }
+
+    public int ToKelvin(int mired)
+    {
+        return (int)Math.Round(1_000_000.0 / mired);
+    }
+
+    public int ToMired(int kelvin)
+    {
+        return (int)Math.Round(1_000_000.0 / kelvin);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Sync/NormalizedLightState.cs
+++ b/LoxNet.Bridge/src/Bridge/Sync/NormalizedLightState.cs
@@ -1,0 +1,6 @@
+namespace LoxNet.Bridge.Sync;
+
+public record NormalizedLightState(bool? Power, int? BrightnessPct, int? Kelvin, (int H, int S, int V)? Hsv)
+{
+    public static NormalizedLightState Empty { get; } = new(null, null, null, null);
+}

--- a/LoxNet.Bridge/src/Bridge/Sync/StateCache.cs
+++ b/LoxNet.Bridge/src/Bridge/Sync/StateCache.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using LoxNet.Bridge.Config;
+
+namespace LoxNet.Bridge.Sync;
+
+public class StateCache
+{
+    private readonly ConcurrentDictionary<string, MappingState> _states = new(StringComparer.OrdinalIgnoreCase);
+
+    public MappingState GetOrCreate(MappingSection mapping)
+    {
+        return _states.GetOrAdd(mapping.MqttTopic, _ => new MappingState(mapping));
+    }
+
+    public IEnumerable<MappingState> AllStates => _states.Values;
+}
+
+public class MappingState
+{
+    public MappingState(MappingSection mapping)
+    {
+        Mapping = mapping;
+    }
+
+    public MappingSection Mapping { get; }
+
+    public NormalizedLightState LastObservedMqtt { get; set; } = NormalizedLightState.Empty;
+
+    public NormalizedLightState LastObservedLoxone { get; set; } = NormalizedLightState.Empty;
+
+    public NormalizedLightState LastSentToMqtt { get; set; } = NormalizedLightState.Empty;
+
+    public NormalizedLightState LastSentToLoxone { get; set; } = NormalizedLightState.Empty;
+}

--- a/LoxNet.Bridge/src/Bridge/Sync/StateComparer.cs
+++ b/LoxNet.Bridge/src/Bridge/Sync/StateComparer.cs
@@ -1,0 +1,63 @@
+using LoxNet.Bridge.Config;
+
+namespace LoxNet.Bridge.Sync;
+
+public class StateComparer
+{
+    private readonly BridgeConfig _config;
+
+    public StateComparer(BridgeConfig config)
+    {
+        _config = config;
+    }
+
+    public bool AreEqual(NormalizedLightState left, NormalizedLightState right)
+    {
+        if (left.Power != right.Power)
+        {
+            return false;
+        }
+
+        if (!EqualWithTolerance(left.BrightnessPct, right.BrightnessPct, _config.Sync.BrightnessTolerancePct))
+        {
+            return false;
+        }
+
+        if (!EqualWithTolerance(left.Kelvin, right.Kelvin, _config.Sync.KelvinTolerance))
+        {
+            return false;
+        }
+
+        if (left.Hsv.HasValue != right.Hsv.HasValue)
+        {
+            return false;
+        }
+
+        if (left.Hsv.HasValue && right.Hsv.HasValue)
+        {
+            var l = left.Hsv.Value;
+            var r = right.Hsv.Value;
+            if (l.H != r.H || l.S != r.S || l.V != r.V)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool EqualWithTolerance(int? left, int? right, int tolerance)
+    {
+        if (!left.HasValue && !right.HasValue)
+        {
+            return true;
+        }
+
+        if (!left.HasValue || !right.HasValue)
+        {
+            return false;
+        }
+
+        return Math.Abs(left.Value - right.Value) <= tolerance;
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Sync/SyncEngine.cs
+++ b/LoxNet.Bridge/src/Bridge/Sync/SyncEngine.cs
@@ -1,0 +1,104 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Mqtt;
+using Microsoft.Extensions.Logging;
+
+namespace LoxNet.Bridge.Sync;
+
+public class SyncEngine
+{
+    private readonly BridgeConfig _config;
+    private readonly StateCache _cache;
+    private readonly StateComparer _comparer;
+    private readonly LoxoneCommandBuilder _commandBuilder;
+    private readonly ILoxoneCommandExecutor _loxoneService;
+    private readonly Z2mPublisher _publisher;
+    private readonly IMqttPublisher _mqttPublisher;
+    private readonly ILogger<SyncEngine> _logger;
+
+    public SyncEngine(BridgeConfig config, StateCache cache, StateComparer comparer, LoxoneCommandBuilder commandBuilder, ILoxoneCommandExecutor loxoneService, Z2mPublisher publisher, IMqttPublisher mqttPublisher, ILogger<SyncEngine> logger)
+    {
+        _config = config;
+        _cache = cache;
+        _comparer = comparer;
+        _commandBuilder = commandBuilder;
+        _loxoneService = loxoneService;
+        _publisher = publisher;
+        _mqttPublisher = mqttPublisher;
+        _logger = logger;
+    }
+
+    public Task ProcessMqttAsync(string topic, NormalizedLightState state, CancellationToken cancellationToken)
+    {
+        var mapping = _config.Mappings.FirstOrDefault(m => string.Equals(m.MqttTopic, topic, StringComparison.OrdinalIgnoreCase));
+        if (mapping is null)
+        {
+            _logger.LogDebug("Ignoring MQTT topic {Topic} without mapping", topic);
+            return Task.CompletedTask;
+        }
+
+        var cache = _cache.GetOrCreate(mapping);
+        cache.LastObservedMqtt = state;
+
+        if (_comparer.AreEqual(state, cache.LastSentToLoxone))
+        {
+            _logger.LogDebug("Ignoring MQTT echo for {Topic}", topic);
+            return Task.CompletedTask;
+        }
+
+        var commands = _commandBuilder.BuildCommands(mapping, state);
+        return ForwardToLoxoneAsync(mapping, cache, commands, state, cancellationToken);
+    }
+
+    public Task ProcessLoxoneAsync(string uuidAction, NormalizedLightState state, CancellationToken cancellationToken)
+    {
+        var mapping = _config.Mappings.FirstOrDefault(m => string.Equals(m.LoxoneUuidAction, uuidAction, StringComparison.OrdinalIgnoreCase));
+        if (mapping is null)
+        {
+            _logger.LogDebug("Ignoring Loxone state for unmapped uuidAction {Uuid}", uuidAction);
+            return Task.CompletedTask;
+        }
+
+        var cache = _cache.GetOrCreate(mapping);
+        cache.LastObservedLoxone = state;
+
+        if (_comparer.AreEqual(state, cache.LastSentToMqtt))
+        {
+            _logger.LogDebug("Ignoring Loxone echo for {Uuid}", uuidAction);
+            return Task.CompletedTask;
+        }
+
+        return ForwardToMqttAsync(mapping, cache, state, cancellationToken);
+    }
+
+    private async Task ForwardToLoxoneAsync(MappingSection mapping, MappingState cache, IReadOnlyList<string> commands, NormalizedLightState state, CancellationToken cancellationToken)
+    {
+        if (commands.Count == 0)
+        {
+            _logger.LogDebug("No Loxone commands generated for {Name}", mapping.Name);
+            return;
+        }
+
+        await _loxoneService.SendCommandsAsync(mapping, commands, cancellationToken).ConfigureAwait(false);
+        cache.LastSentToLoxone = state;
+    }
+
+    private async Task ForwardToMqttAsync(MappingSection mapping, MappingState cache, NormalizedLightState state, CancellationToken cancellationToken)
+    {
+        if (!_mqttPublisher.IsConnected)
+        {
+            _logger.LogWarning("MQTT client is not connected; skipping publish for {Topic}", mapping.MqttTopic);
+            return;
+        }
+
+        var payload = _publisher.BuildPayload(state, cache.LastSentToMqtt);
+        if (string.Equals(payload, "{}", StringComparison.Ordinal))
+        {
+            _logger.LogDebug("MQTT payload empty for {Topic}", mapping.MqttTopic);
+            return;
+        }
+
+        await _mqttPublisher.PublishAsync(mapping, state, cache.LastSentToMqtt, cancellationToken).ConfigureAwait(false);
+        cache.LastSentToMqtt = state;
+    }
+}

--- a/LoxNet.Bridge/tests/Bridge.Tests/ColorPickerParsingTests.cs
+++ b/LoxNet.Bridge/tests/Bridge.Tests/ColorPickerParsingTests.cs
@@ -1,0 +1,26 @@
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Sync;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Bridge.Tests;
+
+public class ColorPickerParsingTests
+{
+    private readonly LoxoneStateParser _parser = new(new NullLogger<LoxoneStateParser>());
+
+    [Fact]
+    public void ParsesHsv()
+    {
+        var state = _parser.FromColorPicker("hsv(0,100,100)");
+        Assert.Equal((0, 100, 100), state.Hsv);
+    }
+
+    [Fact]
+    public void ParsesTemp()
+    {
+        var state = _parser.FromColorPicker("temp(100,4483)");
+        Assert.Equal(100, state.BrightnessPct);
+        Assert.Equal(4483, state.Kelvin);
+    }
+}

--- a/LoxNet.Bridge/tests/Bridge.Tests/CommandBuilderTests.cs
+++ b/LoxNet.Bridge/tests/Bridge.Tests/CommandBuilderTests.cs
@@ -1,0 +1,61 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Sync;
+using Xunit;
+
+namespace Bridge.Tests;
+
+public class CommandBuilderTests
+{
+    private readonly LoxoneCommandBuilder _builder = new();
+
+    [Fact]
+    public void DimmerCommandsRespectPower()
+    {
+        var mapping = CreateMapping("dimmer");
+        var commands = _builder.BuildCommands(mapping, new NormalizedLightState(true, null, null, null));
+        Assert.Contains("on", commands);
+    }
+
+    [Fact]
+    public void DimmerCommandsIncludeBrightness()
+    {
+        var mapping = CreateMapping("dimmer");
+        var commands = _builder.BuildCommands(mapping, new NormalizedLightState(null, 42, null, null));
+        Assert.Contains("42", commands);
+    }
+
+    [Fact]
+    public void ColorPickerTempCommand()
+    {
+        var mapping = CreateMapping("colorpickerv2");
+        var commands = _builder.BuildCommands(mapping, new NormalizedLightState(null, 80, 3000, null));
+        Assert.Contains("temp(80,3000)", commands);
+    }
+
+    [Fact]
+    public void ColorPickerBrightnessCommand()
+    {
+        var mapping = CreateMapping("colorpickerv2");
+        var commands = _builder.BuildCommands(mapping, new NormalizedLightState(null, 50, null, null));
+        Assert.Contains("setBrightness/50", commands);
+    }
+
+    [Fact]
+    public void ColorPickerHsvCommand()
+    {
+        var mapping = CreateMapping("colorpickerv2");
+        var commands = _builder.BuildCommands(mapping, new NormalizedLightState(null, null, null, (10, 20, 30)));
+        Assert.Contains("hsv(10,20,30)", commands);
+    }
+
+    private static MappingSection CreateMapping(string kind)
+    {
+        return new MappingSection
+        {
+            Kind = kind,
+            LoxoneUuidAction = Guid.NewGuid().ToString(),
+            MqttTopic = "zigbee2mqtt/device"
+        };
+    }
+}

--- a/LoxNet.Bridge/tests/Bridge.Tests/ConvertersTests.cs
+++ b/LoxNet.Bridge/tests/Bridge.Tests/ConvertersTests.cs
@@ -1,0 +1,47 @@
+using LoxNet.Bridge.Sync;
+using Xunit;
+
+namespace Bridge.Tests;
+
+public class ConvertersTests
+{
+    private readonly Converters _converters = new();
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(254, 100)]
+    public void ToBrightnessPercent_MapsRange(int input, int expected)
+    {
+        var percent = _converters.ToBrightnessPercent(input);
+        Assert.Equal(expected, percent);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(100, 254)]
+    public void ToMqttBrightness_MapsRange(int pct, int expected)
+    {
+        var brightness = _converters.ToMqttBrightness(pct);
+        Assert.Equal(expected, brightness);
+    }
+
+    [Fact]
+    public void Brightness_RoundTripWithinTolerance()
+    {
+        for (var pct = 0; pct <= 100; pct += 10)
+        {
+            var mqtt = _converters.ToMqttBrightness(pct);
+            var roundTrip = _converters.ToBrightnessPercent(mqtt);
+            Assert.InRange(roundTrip, pct - 1, pct + 1);
+        }
+    }
+
+    [Fact]
+    public void Kelvin_Mired_RoundTrip()
+    {
+        var kelvin = 4483;
+        var mired = _converters.ToMired(kelvin);
+        var roundTrip = _converters.ToKelvin(mired);
+        Assert.InRange(roundTrip, kelvin - 25, kelvin + 25);
+    }
+}

--- a/LoxNet.Bridge/tests/Bridge.Tests/DedupingTests.cs
+++ b/LoxNet.Bridge/tests/Bridge.Tests/DedupingTests.cs
@@ -1,0 +1,79 @@
+using LoxNet.Bridge.Config;
+using LoxNet.Bridge.Loxone;
+using LoxNet.Bridge.Mqtt;
+using LoxNet.Bridge.Sync;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Bridge.Tests;
+
+public class DedupingTests
+{
+    private readonly MappingSection _mapping = new()
+    {
+        Name = "Test",
+        Kind = "dimmer",
+        LoxoneUuidAction = Guid.NewGuid().ToString(),
+        MqttTopic = "zigbee2mqtt/test"
+    };
+
+    [Fact]
+    public async Task MqttEchoIsSuppressed()
+    {
+        var config = new BridgeConfig { Mappings = new[] { _mapping } };
+        var cache = new StateCache();
+        var comparer = new StateComparer(config);
+        var fakeLoxone = new FakeLoxoneExecutor();
+        var fakePublisher = new FakeMqttPublisher();
+        var engine = new SyncEngine(config, cache, comparer, new LoxoneCommandBuilder(), fakeLoxone, new Z2mPublisher(new Converters()), fakePublisher, NullLogger<SyncEngine>.Instance);
+
+        var state = new NormalizedLightState(true, 50, null, null);
+        cache.GetOrCreate(_mapping).LastSentToLoxone = state;
+
+        await engine.ProcessMqttAsync(_mapping.MqttTopic, state, CancellationToken.None);
+
+        Assert.Empty(fakeLoxone.Commands);
+    }
+
+    [Fact]
+    public async Task LoxoneEchoIsSuppressed()
+    {
+        var config = new BridgeConfig { Mappings = new[] { _mapping } };
+        var cache = new StateCache();
+        var comparer = new StateComparer(config);
+        var fakeLoxone = new FakeLoxoneExecutor();
+        var fakePublisher = new FakeMqttPublisher();
+        var engine = new SyncEngine(config, cache, comparer, new LoxoneCommandBuilder(), fakeLoxone, new Z2mPublisher(new Converters()), fakePublisher, NullLogger<SyncEngine>.Instance);
+
+        var state = new NormalizedLightState(true, 50, null, null);
+        cache.GetOrCreate(_mapping).LastSentToMqtt = state;
+
+        await engine.ProcessLoxoneAsync(_mapping.LoxoneUuidAction, state, CancellationToken.None);
+
+        Assert.Empty(fakePublisher.PublishedStates);
+    }
+
+    private sealed class FakeLoxoneExecutor : ILoxoneCommandExecutor
+    {
+        public List<string> Commands { get; } = new();
+
+        public Task SendCommandsAsync(MappingSection mapping, IEnumerable<string> commands, CancellationToken cancellationToken)
+        {
+            Commands.AddRange(commands);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeMqttPublisher : IMqttPublisher
+    {
+        public List<NormalizedLightState> PublishedStates { get; } = new();
+
+        public bool IsConnected { get; set; } = true;
+
+        public Task PublishAsync(MappingSection mapping, NormalizedLightState desired, NormalizedLightState lastSent, CancellationToken cancellationToken)
+        {
+            PublishedStates.Add(desired);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/LoxNet.Bridge/tests/Bridge.Tests/LoxNet.Bridge.Tests.csproj
+++ b/LoxNet.Bridge/tests/Bridge.Tests/LoxNet.Bridge.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.6.6" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Bridge/Bridge.csproj" />
+  </ItemGroup>
+</Project>

--- a/LoxNet.Client/Controls/LoxoneControlFactory.cs
+++ b/LoxNet.Client/Controls/LoxoneControlFactory.cs
@@ -13,6 +13,8 @@ public static class LoxoneControlFactory
         ControlType.Switch => new SwitchControl(),
         ControlType.LightController => new LightController(),
         ControlType.LightControllerV2 => new LightControllerV2(),
+        ControlType.Dimmer => new LoxoneControl(),
+        ControlType.ColorPickerV2 => new LoxoneControl(),
         _ => new LoxoneControl()
     };
 

--- a/LoxNet.Client/LoxoneStructureState.cs
+++ b/LoxNet.Client/LoxoneStructureState.cs
@@ -108,6 +108,8 @@ public class LoxoneStructureState : ILoxoneStructureState
             "Switch" => ControlType.Switch,
             "LightController" => ControlType.LightController,
             "LightControllerV2" => ControlType.LightControllerV2,
+            "Dimmer" => ControlType.Dimmer,
+            "ColorPickerV2" => ControlType.ColorPickerV2,
             _ => ControlType.Unknown
         };
 

--- a/LoxNet.Client/Models/ControlType.cs
+++ b/LoxNet.Client/Models/ControlType.cs
@@ -12,5 +12,9 @@ public enum ControlType
     /// <summary>A lighting controller.</summary>
     LightController,
     /// <summary>Second version of the lighting controller.</summary>
-    LightControllerV2
+    LightControllerV2,
+    /// <summary>A dimmer circuit.</summary>
+    Dimmer,
+    /// <summary>A color picker circuit used by LightControllerV2.</summary>
+    ColorPickerV2
 }


### PR DESCRIPTION
## Summary
- add a new LoxNet.Bridge project that synchronizes Zigbee2MQTT topics with Loxone LightControllerV2 subcontrols using the existing client
- implement configuration loading, MQTT integration, Loxone command/state parsing, sync engine, minimal discovery API, and container assets
- extend the base client to recognize Dimmer and ColorPickerV2 subcontrol types and provide unit tests for conversions, parsing, and deduping

## Testing
- `dotnet test ./LoxNet.Bridge/tests/Bridge.Tests/LoxNet.Bridge.Tests.csproj` *(fails in this environment because MSBuild's terminal logger crashes before running tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3de3ff5483269b7f6070b45967e8)