### PR TITLE
Add Blazor configuration UI and config endpoints for bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.userosscache
 *.sln.docstates
 *.env
+LoxNet.Bridge/data/config.yaml
+LoxNet.Bridge/data/config.yml
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      
+    {
+      "name": "LoxNet.Bridge (net9.0)",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/LoxNet.Bridge/src/Bridge/bin/Debug/net9.0/Bridge.dll",
+      "cwd": "${workspaceFolder}/LoxNet.Bridge/src/Bridge",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "CONFIG": "${workspaceFolder}/LoxNet.Bridge/data/config.yaml"
+      }
+    }
+  ]
+}

--- a/LoxNet.Bridge/LoxNet.Bridge.slnx
+++ b/LoxNet.Bridge/LoxNet.Bridge.slnx
@@ -1,0 +1,22 @@
+
+<Solution>
+  <SolutionProperties VisualStudioVersion="17.0" MinimumVisualStudioVersion="17.0" />
+
+  <Projects>
+    <!-- Project entries use a relative path from the .slnx file -->
+    <Project Path="src/Bridge/Bridge.csproj" Type="CSharp" />
+  </Projects>
+
+  <SolutionConfigurations>
+    <Configuration Name="Debug|AnyCPU" />
+    <Configuration Name="Release|AnyCPU" />
+  </SolutionConfigurations>
+  <Folder Name="/src/">
+    <Project Path="src/Bridge/Bridge.csproj" />
+  </Folder>
+  <Folder Name="/tests/" />
+  <Folder Name="/tests/Bridge.Tests/">
+    <Project Path="tests/Bridge.Tests/LoxNet.Bridge.Tests.csproj" />
+  </Folder>
+  <Project Path="../LoxNet.Client/LoxNet.Client.csproj" />
+</Solution>

--- a/LoxNet.Bridge/README.md
+++ b/LoxNet.Bridge/README.md
@@ -8,7 +8,7 @@ A lightweight service that bridges Zigbee2MQTT devices with Loxone LightControll
    ```sh
    docker compose -f docker-compose.example.yml up --build
    ```
-2. Place your configuration file at `./data/config.yaml` or set `CONFIG` to another path.
+2. Copy `./data/config.example.yaml` to `./data/config.yaml` and update the credentials, or set `CONFIG` to another path.
 3. Browse `http://localhost:8080/health` to confirm connectivity and mapping status.
 
 ## Discovering Loxone subcontrols

--- a/LoxNet.Bridge/data/config.example.yaml
+++ b/LoxNet.Bridge/data/config.example.yaml
@@ -1,0 +1,15 @@
+loxone:
+  host: "LOXONE_HOST_OR_IP"
+  user: "bridge-user"
+  password: "change-me"
+
+mqtt:
+  host: "localhost"
+
+mappings:
+  - name: "Example dimmer"
+    kind: "dimmer"
+    mqttTopic: "zigbee2mqtt/example_dimmer"
+    loxoneUuidAction: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    options:
+      preferMqttState: true

--- a/LoxNet.Bridge/src/Bridge/Api/BridgeConfigDto.cs
+++ b/LoxNet.Bridge/src/Bridge/Api/BridgeConfigDto.cs
@@ -1,0 +1,71 @@
+namespace LoxNet.Bridge.Api;
+
+public sealed record BridgeConfigDto
+{
+    public required LoxoneSectionDto Loxone { get; init; }
+
+    public required MqttSectionDto Mqtt { get; init; }
+
+    public required IReadOnlyList<MappingSectionDto> Mappings { get; init; }
+}
+
+public sealed record LoxoneSectionDto
+{
+    public required string Host { get; init; }
+
+    public int Port { get; init; } = 80;
+
+    public bool UseHttps { get; init; }
+
+    public required string User { get; init; }
+
+    public required string Password { get; init; }
+
+    public string? Loxapp3Path { get; init; }
+
+    public bool RefreshLoxapp3OnStart { get; init; } = true;
+}
+
+public sealed record MqttSectionDto
+{
+    public required string Host { get; init; }
+
+    public int Port { get; init; } = 1883;
+
+    public string? Username { get; init; }
+
+    public string? Password { get; init; }
+
+    public string ClientId { get; init; } = "loxone-z2m-bridge";
+
+    public string BaseTopic { get; init; } = "zigbee2mqtt";
+}
+
+public sealed record MappingSectionDto
+{
+    public required string Name { get; init; }
+
+    public required string Kind { get; init; }
+
+    public required string MqttTopic { get; init; }
+
+    public required string LoxoneUuidAction { get; init; }
+
+    public MappingOptionsDto Options { get; init; } = new();
+}
+
+public sealed record MappingOptionsDto
+{
+    public bool PreferMqttState { get; init; }
+
+    public bool AllowColor { get; init; } = true;
+}
+
+public sealed record ConfigSaveResult
+{
+    public required string Message { get; init; }
+
+    public required string Path { get; init; }
+
+    public bool RequiresRestart { get; init; }
+}

--- a/LoxNet.Bridge/src/Bridge/Api/BridgeConfigMapper.cs
+++ b/LoxNet.Bridge/src/Bridge/Api/BridgeConfigMapper.cs
@@ -86,7 +86,7 @@ public static class BridgeConfigMapper
                         AllowColor = m.Options.AllowColor
                     }
                 })
-                .ToArray()
+                .ToList()
         };
     }
 }

--- a/LoxNet.Bridge/src/Bridge/Api/BridgeConfigMapper.cs
+++ b/LoxNet.Bridge/src/Bridge/Api/BridgeConfigMapper.cs
@@ -1,0 +1,92 @@
+using LoxNet.Bridge.Config;
+
+namespace LoxNet.Bridge.Api;
+
+public static class BridgeConfigMapper
+{
+    public static BridgeConfigDto ToDto(BridgeConfig config)
+    {
+        return new BridgeConfigDto
+        {
+            Loxone = new LoxoneSectionDto
+            {
+                Host = config.Loxone.Host,
+                Port = config.Loxone.Port,
+                UseHttps = config.Loxone.UseHttps,
+                User = config.Loxone.User,
+                Password = config.Loxone.Password,
+                Loxapp3Path = config.Loxone.Loxapp3Path,
+                RefreshLoxapp3OnStart = config.Loxone.RefreshLoxapp3OnStart
+            },
+            Mqtt = new MqttSectionDto
+            {
+                Host = config.Mqtt.Host,
+                Port = config.Mqtt.Port,
+                Username = config.Mqtt.Username,
+                Password = config.Mqtt.Password,
+                ClientId = config.Mqtt.ClientId,
+                BaseTopic = config.Mqtt.BaseTopic
+            },
+            Mappings = config.Mappings
+                .Select(m => new MappingSectionDto
+                {
+                    Name = m.Name,
+                    Kind = m.Kind,
+                    MqttTopic = m.MqttTopic,
+                    LoxoneUuidAction = m.LoxoneUuidAction,
+                    Options = new MappingOptionsDto
+                    {
+                        PreferMqttState = m.Options.PreferMqttState,
+                        AllowColor = m.Options.AllowColor
+                    }
+                })
+                .ToArray()
+        };
+    }
+
+    public static BridgeConfig ToConfig(BridgeConfigDto dto, SyncSection syncSection)
+    {
+        return new BridgeConfig
+        {
+            Loxone = new LoxoneSection
+            {
+                Host = dto.Loxone.Host,
+                Port = dto.Loxone.Port,
+                UseHttps = dto.Loxone.UseHttps,
+                User = dto.Loxone.User,
+                Password = dto.Loxone.Password,
+                Loxapp3Path = dto.Loxone.Loxapp3Path,
+                RefreshLoxapp3OnStart = dto.Loxone.RefreshLoxapp3OnStart
+            },
+            Mqtt = new MqttSection
+            {
+                Host = dto.Mqtt.Host,
+                Port = dto.Mqtt.Port,
+                Username = dto.Mqtt.Username,
+                Password = dto.Mqtt.Password,
+                ClientId = dto.Mqtt.ClientId,
+                BaseTopic = dto.Mqtt.BaseTopic
+            },
+            Sync = new SyncSection
+            {
+                BrightnessTolerancePct = syncSection.BrightnessTolerancePct,
+                KelvinTolerance = syncSection.KelvinTolerance,
+                SuppressEchoWindowMs = syncSection.SuppressEchoWindowMs
+            },
+            Mappings = dto.Mappings
+                .Select(m => new MappingSection
+                {
+                    Name = m.Name,
+                    Kind = m.Kind,
+                    MqttTopic = m.MqttTopic,
+                    LoxoneUuidAction = m.LoxoneUuidAction,
+                    Options = new MappingOptions
+                    {
+                        PreferMqttState = m.Options.PreferMqttState,
+                        AllowColor = m.Options.AllowColor
+                    }
+                })
+                .ToArray()
+        };
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Api/MinimalApiHost.cs
+++ b/LoxNet.Bridge/src/Bridge/Api/MinimalApiHost.cs
@@ -3,22 +3,27 @@ using LoxNet.Bridge.Loxone;
 using LoxNet.Bridge.Mqtt;
 using LoxNet.Bridge.Sync;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using LoxNet;
+using LoxNet.Bridge.Ui;
+using System.ComponentModel.DataAnnotations;
 
 namespace LoxNet.Bridge.Api;
 
 public class MinimalApiHost : IHostedService
 {
     private readonly BridgeConfig _config;
+    private readonly ConfigFileSettings _configFileSettings;
     private readonly MqttService _mqttService;
     private readonly LoxoneService _loxoneService;
     private IHost? _webHost;
 
-    public MinimalApiHost(BridgeConfig config, MqttService mqttService, LoxoneService loxoneService)
+    public MinimalApiHost(BridgeConfig config, ConfigFileSettings configFileSettings, MqttService mqttService, LoxoneService loxoneService)
     {
         _config = config;
+        _configFileSettings = configFileSettings;
         _mqttService = mqttService;
         _loxoneService = loxoneService;
     }
@@ -34,11 +39,22 @@ public class MinimalApiHost : IHostedService
         builder.Logging.ClearProviders();
         builder.Logging.AddConsole();
 
+        builder.Services.AddRazorComponents()
+            .AddInteractiveServerComponents();
+        builder.Services.AddHttpClient();
+
         var app = builder.Build();
+
+        app.UseStaticFiles();
+        app.UseAntiforgery();
 
         app.MapGet("/health", () => BuildHealth());
         app.MapGet("/discover/loxone/subcontrols", () => DiscoverLoxoneSubcontrols());
         app.MapGet("/discover/mqtt/devices", () => new { devices = Array.Empty<string>(), hint = "Subscribe to zigbee2mqtt/bridge/devices for details" });
+        app.MapGet("/config", () => Results.Ok(BridgeConfigMapper.ToDto(_config)));
+        app.MapPost("/config", async (BridgeConfigDto payload) => await SaveConfigAsync(payload).ConfigureAwait(false));
+        app.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
 
         _webHost = app;
         await app.StartAsync(cancellationToken).ConfigureAwait(false);
@@ -120,5 +136,33 @@ public class MinimalApiHost : IHostedService
             "colorpickerv2" => type == ControlType.ColorPickerV2,
             _ => false
         };
+    }
+
+    private async Task<IResult> SaveConfigAsync(BridgeConfigDto payload)
+    {
+        try
+        {
+            var updatedConfig = BridgeConfigMapper.ToConfig(payload, _config.Sync);
+            updatedConfig.Validate();
+            var yaml = ConfigYamlSerializer.Serialize(updatedConfig);
+            var directory = Path.GetDirectoryName(_configFileSettings.Path);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await File.WriteAllTextAsync(_configFileSettings.Path, yaml).ConfigureAwait(false);
+
+            return Results.Ok(new ConfigSaveResult
+            {
+                Message = "Configuration saved. Restart the bridge to apply the new settings.",
+                Path = _configFileSettings.Path,
+                RequiresRestart = true
+            });
+        }
+        catch (ValidationException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
     }
 }

--- a/LoxNet.Bridge/src/Bridge/Bridge.csproj
+++ b/LoxNet.Bridge/src/Bridge/Bridge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
@@ -13,6 +13,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../LoxNet.Client/LoxNet.Client.csproj" />
+    <ProjectReference Include="../../../LoxNet.Client/LoxNet.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/LoxNet.Bridge/src/Bridge/Config/BridgeConfig.cs
+++ b/LoxNet.Bridge/src/Bridge/Config/BridgeConfig.cs
@@ -10,7 +10,7 @@ public class BridgeConfig
 
     public SyncSection Sync { get; init; } = new();
 
-    public IReadOnlyList<MappingSection> Mappings { get; init; } = Array.Empty<MappingSection>();
+    public List<MappingSection> Mappings { get; init; } = new();
 
     public void Validate()
     {

--- a/LoxNet.Bridge/src/Bridge/Config/ConfigFileSettings.cs
+++ b/LoxNet.Bridge/src/Bridge/Config/ConfigFileSettings.cs
@@ -1,0 +1,3 @@
+namespace LoxNet.Bridge.Config;
+
+public sealed record ConfigFileSettings(string Path);

--- a/LoxNet.Bridge/src/Bridge/Config/ConfigLoader.cs
+++ b/LoxNet.Bridge/src/Bridge/Config/ConfigLoader.cs
@@ -9,16 +9,7 @@ public static class ConfigLoader
 {
     public static async Task<BridgeConfig> LoadAsync(IConfiguration configuration, string? configPathFromEnv)
     {
-        var path = configPathFromEnv;
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            path = configuration["CONFIG"];
-        }
-
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            path = "/data/config.yaml";
-        }
+        var path = ResolvePath(configuration, configPathFromEnv);
 
         if (!File.Exists(path))
         {
@@ -37,5 +28,21 @@ public static class ConfigLoader
         var config = deserializer.Deserialize<BridgeConfig>(yaml) ?? new BridgeConfig();
         config.Validate();
         return config;
+    }
+
+    public static string ResolvePath(IConfiguration configuration, string? configPathFromEnv)
+    {
+        var path = configPathFromEnv;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = configuration["CONFIG"];
+        }
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = "/data/config.yaml";
+        }
+
+        return path;
     }
 }

--- a/LoxNet.Bridge/src/Bridge/Config/ConfigYamlSerializer.cs
+++ b/LoxNet.Bridge/src/Bridge/Config/ConfigYamlSerializer.cs
@@ -1,0 +1,16 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace LoxNet.Bridge.Config;
+
+public static class ConfigYamlSerializer
+{
+    private static readonly ISerializer Serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static string Serialize(BridgeConfig config)
+    {
+        return Serializer.Serialize(config);
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Loxone/LoxoneService.cs
+++ b/LoxNet.Bridge/src/Bridge/Loxone/LoxoneService.cs
@@ -76,7 +76,7 @@ public class LoxoneService : ILoxoneCommandExecutor
 
             control.StateChanged += async (_, args) =>
             {
-                await HandleStateAsync(mapping, args.Name, args.Value, cancellationToken).ConfigureAwait(false);
+                await HandleStateAsync(mapping, args.State, args.Value, cancellationToken).ConfigureAwait(false);
             };
         }
     }

--- a/LoxNet.Bridge/src/Bridge/Mqtt/IMqttClientHost.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/IMqttClientHost.cs
@@ -1,4 +1,4 @@
-using MQTTnet.Client;
+using MQTTnet;
 
 namespace LoxNet.Bridge.Mqtt;
 

--- a/LoxNet.Bridge/src/Bridge/Mqtt/MqttPublisherAdapter.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/MqttPublisherAdapter.cs
@@ -1,6 +1,6 @@
 using LoxNet.Bridge.Config;
 using LoxNet.Bridge.Sync;
-using MQTTnet.Client;
+using MQTTnet;
 
 namespace LoxNet.Bridge.Mqtt;
 

--- a/LoxNet.Bridge/src/Bridge/Mqtt/MqttService.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/MqttService.cs
@@ -1,8 +1,8 @@
+using System.Buffers;
 using LoxNet.Bridge.Config;
 using LoxNet.Bridge.Sync;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
-using MQTTnet.Client;
 
 namespace LoxNet.Bridge.Mqtt;
 
@@ -16,7 +16,7 @@ public class MqttService : IMqttClientHost
     {
         _logger = logger;
         _parser = parser;
-        _client = client ?? new MqttFactory().CreateMqttClient();
+        _client = client ?? new MqttClientFactory().CreateMqttClient();
     }
 
     public IMqttClient Client => _client;
@@ -34,7 +34,7 @@ public class MqttService : IMqttClientHost
             var topic = args.ApplicationMessage.Topic;
             try
             {
-                var payload = args.ApplicationMessage.PayloadSegment.ToArray();
+                var payload = args.ApplicationMessage.Payload.ToArray();
                 var json = System.Text.Encoding.UTF8.GetString(payload);
                 var state = _parser.Parse(json);
                 return handler(topic, state, cancellationToken);
@@ -68,6 +68,7 @@ public class MqttService : IMqttClientHost
         var topics = config.Mappings.Select(m => m.MqttTopic).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         var options = topics.Select(t => new MqttTopicFilterBuilder().WithTopic(t).Build()).ToList();
         _logger.LogInformation("Subscribing to {Count} MQTT topics", options.Count);
-        return _client.SubscribeAsync(options, cancellationToken);
+        var subscribeOptions = new MqttClientSubscribeOptions { TopicFilters = options };
+        return _client.SubscribeAsync(subscribeOptions, cancellationToken);
     }
 }

--- a/LoxNet.Bridge/src/Bridge/Mqtt/Z2mPublisher.cs
+++ b/LoxNet.Bridge/src/Bridge/Mqtt/Z2mPublisher.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using MQTTnet;
-using MQTTnet.Client;
 using MQTTnet.Protocol;
 using LoxNet.Bridge.Config;
 using LoxNet.Bridge.Sync;

--- a/LoxNet.Bridge/src/Bridge/Program.cs
+++ b/LoxNet.Bridge/src/Bridge/Program.cs
@@ -9,8 +9,10 @@ using LoxNet.Bridge.Sync;
 var builder = Host.CreateApplicationBuilder(args);
 LoggingSetup.Configure(builder.Logging);
 
-var bridgeConfig = await ConfigLoader.LoadAsync(builder.Configuration, builder.Configuration["CONFIG"]);
+var configPath = ConfigLoader.ResolvePath(builder.Configuration, builder.Configuration["CONFIG"]);
+var bridgeConfig = await ConfigLoader.LoadAsync(builder.Configuration, configPath);
 builder.Services.AddSingleton(bridgeConfig);
+builder.Services.AddSingleton(new ConfigFileSettings(configPath));
 builder.Services.AddSingleton<StateCache>();
 builder.Services.AddSingleton<StateComparer>();
 builder.Services.AddSingleton<Converters>();

--- a/LoxNet.Bridge/src/Bridge/Ui/App.razor
+++ b/LoxNet.Bridge/src/Bridge/Ui/App.razor
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LoxNet Bridge Config</title>
+    <link rel="stylesheet" href="app.css" />
+    <HeadOutlet />
+</head>
+<body>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layouts.MainLayout)" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(Layouts.MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/LoxNet.Bridge/src/Bridge/Ui/Layouts/MainLayout.razor
+++ b/LoxNet.Bridge/src/Bridge/Ui/Layouts/MainLayout.razor
@@ -1,0 +1,11 @@
+@inherits LayoutComponentBase
+
+<div class="page">
+    <header class="top-bar">
+        <div class="top-bar__title">LoxNet Bridge Configuration</div>
+        <div class="top-bar__subtitle">Miniserver, MQTT, and bridge mappings</div>
+    </header>
+    <main class="content">
+        @Body
+    </main>
+</div>

--- a/LoxNet.Bridge/src/Bridge/Ui/Models/ConfigEditorModel.cs
+++ b/LoxNet.Bridge/src/Bridge/Ui/Models/ConfigEditorModel.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LoxNet.Bridge.Ui;
+
+public class ConfigEditorModel
+{
+    [Required]
+    public LoxoneEditorModel Loxone { get; set; } = new();
+
+    [Required]
+    public MqttEditorModel Mqtt { get; set; } = new();
+
+    public List<MappingEditorModel> Mappings { get; set; } = new();
+}
+
+public class LoxoneEditorModel
+{
+    [Required]
+    public string Host { get; set; } = string.Empty;
+
+    [Range(1, 65535)]
+    public int Port { get; set; } = 80;
+
+    public bool UseHttps { get; set; }
+
+    [Required]
+    public string User { get; set; } = string.Empty;
+
+    [Required]
+    public string Password { get; set; } = string.Empty;
+
+    public string? Loxapp3Path { get; set; }
+
+    public bool RefreshLoxapp3OnStart { get; set; } = true;
+}
+
+public class MqttEditorModel
+{
+    [Required]
+    public string Host { get; set; } = string.Empty;
+
+    [Range(1, 65535)]
+    public int Port { get; set; } = 1883;
+
+    public string? Username { get; set; }
+
+    public string? Password { get; set; }
+
+    public string ClientId { get; set; } = "loxone-z2m-bridge";
+
+    public string BaseTopic { get; set; } = "zigbee2mqtt";
+}
+
+public class MappingEditorModel
+{
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public string Kind { get; set; } = "Dimmer";
+
+    [Required]
+    public string MqttTopic { get; set; } = string.Empty;
+
+    [Required]
+    public string LoxoneUuidAction { get; set; } = string.Empty;
+
+    public MappingOptionsEditorModel Options { get; set; } = new();
+}
+
+public class MappingOptionsEditorModel
+{
+    public bool PreferMqttState { get; set; }
+
+    public bool AllowColor { get; set; } = true;
+}

--- a/LoxNet.Bridge/src/Bridge/Ui/Pages/ConfigPage.razor
+++ b/LoxNet.Bridge/src/Bridge/Ui/Pages/ConfigPage.razor
@@ -1,0 +1,324 @@
+@page "/"
+@inject IHttpClientFactory HttpClientFactory
+@inject NavigationManager Navigation
+
+<section class="panel">
+    <h1>Bridge Configuration</h1>
+    <p class="panel__hint">
+        Update the miniserver connection, MQTT broker, and mapping details. Saving writes the YAML configuration
+        file and requires a bridge restart before changes take effect.
+    </p>
+</section>
+
+@if (_isLoading)
+{
+    <div class="panel">
+        <p>Loading configuration…</p>
+    </div>
+}
+else
+{
+    <EditForm Model="_model" OnValidSubmit="SaveAsync">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+
+        <section class="panel">
+            <h2>Miniserver Connection</h2>
+            <div class="field-grid">
+                <div class="field">
+                    <label>Host</label>
+                    <InputText class="text-input" @bind-Value="_model.Loxone.Host" />
+                </div>
+                <div class="field">
+                    <label>Port</label>
+                    <InputNumber class="text-input" @bind-Value="_model.Loxone.Port" />
+                </div>
+                <div class="field">
+                    <label>User</label>
+                    <InputText class="text-input" @bind-Value="_model.Loxone.User" />
+                </div>
+                <div class="field">
+                    <label>Password</label>
+                    <InputText class="text-input" type="password" @bind-Value="_model.Loxone.Password" />
+                </div>
+                <div class="field">
+                    <label>LoxApp3 Path</label>
+                    <InputText class="text-input" @bind-Value="_model.Loxone.Loxapp3Path" />
+                </div>
+                <div class="field">
+                    <label>Use HTTPS</label>
+                    <InputCheckbox class="checkbox" @bind-Value="_model.Loxone.UseHttps" />
+                </div>
+                <div class="field">
+                    <label>Refresh LoxApp3 on Start</label>
+                    <InputCheckbox class="checkbox" @bind-Value="_model.Loxone.RefreshLoxapp3OnStart" />
+                </div>
+            </div>
+        </section>
+
+        <section class="panel">
+            <h2>MQTT Broker</h2>
+            <div class="field-grid">
+                <div class="field">
+                    <label>Host</label>
+                    <InputText class="text-input" @bind-Value="_model.Mqtt.Host" />
+                </div>
+                <div class="field">
+                    <label>Port</label>
+                    <InputNumber class="text-input" @bind-Value="_model.Mqtt.Port" />
+                </div>
+                <div class="field">
+                    <label>Username</label>
+                    <InputText class="text-input" @bind-Value="_model.Mqtt.Username" />
+                </div>
+                <div class="field">
+                    <label>Password</label>
+                    <InputText class="text-input" type="password" @bind-Value="_model.Mqtt.Password" />
+                </div>
+                <div class="field">
+                    <label>Client ID</label>
+                    <InputText class="text-input" @bind-Value="_model.Mqtt.ClientId" />
+                </div>
+                <div class="field">
+                    <label>Base Topic</label>
+                    <InputText class="text-input" @bind-Value="_model.Mqtt.BaseTopic" />
+                </div>
+            </div>
+        </section>
+
+        <section class="panel">
+            <div class="panel__header">
+                <h2>Mappings</h2>
+                <button type="button" class="button button--secondary" @onclick="AddMapping">Add Mapping</button>
+            </div>
+
+            @if (_model.Mappings.Count == 0)
+            {
+                <p class="panel__hint">No mappings configured yet. Add one to sync a Loxone control with an MQTT topic.</p>
+            }
+            else
+            {
+                @foreach (var mapping in _model.Mappings)
+                {
+                    <div class="mapping-card">
+                        <div class="mapping-card__header">
+                            <h3>@(string.IsNullOrWhiteSpace(mapping.Name) ? "New Mapping" : mapping.Name)</h3>
+                            <button type="button" class="button button--danger" @onclick="() => RemoveMapping(mapping)">Remove</button>
+                        </div>
+                        <div class="field-grid">
+                            <div class="field">
+                                <label>Name</label>
+                                <InputText class="text-input" @bind-Value="mapping.Name" />
+                            </div>
+                            <div class="field">
+                                <label>Kind</label>
+                                <InputSelect class="text-input" @bind-Value="mapping.Kind">
+                                    @foreach (var kind in _supportedKinds)
+                                    {
+                                        <option value="@kind">@kind</option>
+                                    }
+                                </InputSelect>
+                            </div>
+                            <div class="field">
+                                <label>MQTT Topic</label>
+                                <InputText class="text-input" @bind-Value="mapping.MqttTopic" />
+                            </div>
+                            <div class="field">
+                                <label>Loxone UUID Action</label>
+                                <InputText class="text-input" @bind-Value="mapping.LoxoneUuidAction" />
+                            </div>
+                            <div class="field">
+                                <label>Prefer MQTT State</label>
+                                <InputCheckbox class="checkbox" @bind-Value="mapping.Options.PreferMqttState" />
+                            </div>
+                            <div class="field">
+                                <label>Allow Color</label>
+                                <InputCheckbox class="checkbox" @bind-Value="mapping.Options.AllowColor" />
+                            </div>
+                        </div>
+                    </div>
+                }
+            }
+        </section>
+
+        <section class="panel panel--footer">
+            <button type="submit" class="button button--primary" disabled="@_isSaving">Save Configuration</button>
+            @if (!string.IsNullOrWhiteSpace(_statusMessage))
+            {
+                <span class="status status--success">@_statusMessage</span>
+            }
+            @if (!string.IsNullOrWhiteSpace(_errorMessage))
+            {
+                <span class="status status--error">@_errorMessage</span>
+            }
+        </section>
+    </EditForm>
+}
+
+@code {
+    private readonly string[] _supportedKinds = ["Dimmer", "ColorPickerV2"];
+    private ConfigEditorModel _model = new();
+    private bool _isLoading = true;
+    private bool _isSaving;
+    private string? _statusMessage;
+    private string? _errorMessage;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync().ConfigureAwait(false);
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _statusMessage = null;
+        _errorMessage = null;
+        try
+        {
+            var client = CreateClient();
+            var dto = await client.GetFromJsonAsync<BridgeConfigDto>("config").ConfigureAwait(false);
+            if (dto is not null)
+            {
+                _model = MapToEditor(dto);
+            }
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"Failed to load configuration: {ex.Message}";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        _isSaving = true;
+        _statusMessage = null;
+        _errorMessage = null;
+        try
+        {
+            var client = CreateClient();
+            var payload = MapToDto(_model);
+            var response = await client.PostAsJsonAsync("config", payload).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<ConfigSaveResult>().ConfigureAwait(false);
+                _statusMessage = result?.Message ?? "Configuration saved.";
+            }
+            else
+            {
+                var error = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>().ConfigureAwait(false);
+                _errorMessage = error?.TryGetValue("error", out var message) == true
+                    ? message
+                    : $"Failed to save configuration ({(int)response.StatusCode}).";
+            }
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"Failed to save configuration: {ex.Message}";
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private void AddMapping()
+    {
+        _model.Mappings.Add(new MappingEditorModel());
+    }
+
+    private void RemoveMapping(MappingEditorModel mapping)
+    {
+        _model.Mappings.Remove(mapping);
+    }
+
+    private HttpClient CreateClient()
+    {
+        var client = HttpClientFactory.CreateClient();
+        client.BaseAddress = new Uri(Navigation.BaseUri);
+        return client;
+    }
+
+    private static ConfigEditorModel MapToEditor(BridgeConfigDto dto)
+    {
+        return new ConfigEditorModel
+        {
+            Loxone = new LoxoneEditorModel
+            {
+                Host = dto.Loxone.Host,
+                Port = dto.Loxone.Port,
+                UseHttps = dto.Loxone.UseHttps,
+                User = dto.Loxone.User,
+                Password = dto.Loxone.Password,
+                Loxapp3Path = dto.Loxone.Loxapp3Path,
+                RefreshLoxapp3OnStart = dto.Loxone.RefreshLoxapp3OnStart
+            },
+            Mqtt = new MqttEditorModel
+            {
+                Host = dto.Mqtt.Host,
+                Port = dto.Mqtt.Port,
+                Username = dto.Mqtt.Username,
+                Password = dto.Mqtt.Password,
+                ClientId = dto.Mqtt.ClientId,
+                BaseTopic = dto.Mqtt.BaseTopic
+            },
+            Mappings = dto.Mappings
+                .Select(m => new MappingEditorModel
+                {
+                    Name = m.Name,
+                    Kind = m.Kind,
+                    MqttTopic = m.MqttTopic,
+                    LoxoneUuidAction = m.LoxoneUuidAction,
+                    Options = new MappingOptionsEditorModel
+                    {
+                        PreferMqttState = m.Options.PreferMqttState,
+                        AllowColor = m.Options.AllowColor
+                    }
+                })
+                .ToList()
+        };
+    }
+
+    private static BridgeConfigDto MapToDto(ConfigEditorModel model)
+    {
+        return new BridgeConfigDto
+        {
+            Loxone = new LoxoneSectionDto
+            {
+                Host = model.Loxone.Host,
+                Port = model.Loxone.Port,
+                UseHttps = model.Loxone.UseHttps,
+                User = model.Loxone.User,
+                Password = model.Loxone.Password,
+                Loxapp3Path = model.Loxone.Loxapp3Path,
+                RefreshLoxapp3OnStart = model.Loxone.RefreshLoxapp3OnStart
+            },
+            Mqtt = new MqttSectionDto
+            {
+                Host = model.Mqtt.Host,
+                Port = model.Mqtt.Port,
+                Username = model.Mqtt.Username,
+                Password = model.Mqtt.Password,
+                ClientId = model.Mqtt.ClientId,
+                BaseTopic = model.Mqtt.BaseTopic
+            },
+            Mappings = model.Mappings
+                .Select(m => new MappingSectionDto
+                {
+                    Name = m.Name,
+                    Kind = m.Kind,
+                    MqttTopic = m.MqttTopic,
+                    LoxoneUuidAction = m.LoxoneUuidAction,
+                    Options = new MappingOptionsDto
+                    {
+                        PreferMqttState = m.Options.PreferMqttState,
+                        AllowColor = m.Options.AllowColor
+                    }
+                })
+                .ToArray()
+        };
+    }
+}

--- a/LoxNet.Bridge/src/Bridge/Ui/_Imports.razor
+++ b/LoxNet.Bridge/src/Bridge/Ui/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.ComponentModel.DataAnnotations
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using LoxNet.Bridge.Api
+@namespace LoxNet.Bridge.Ui

--- a/LoxNet.Bridge/src/Bridge/wwwroot/app.css
+++ b/LoxNet.Bridge/src/Bridge/wwwroot/app.css
@@ -1,0 +1,154 @@
+body {
+    margin: 0;
+    font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    background: #f6f7fb;
+    color: #1e1f23;
+}
+
+.page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.top-bar {
+    background: #1a2b4f;
+    color: #fff;
+    padding: 24px 48px;
+    box-shadow: 0 2px 10px rgba(10, 20, 40, 0.2);
+}
+
+.top-bar__title {
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.top-bar__subtitle {
+    opacity: 0.8;
+    margin-top: 6px;
+}
+
+.content {
+    padding: 32px 48px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.panel {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.panel__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.panel__hint {
+    color: #4b5563;
+    margin-top: 8px;
+}
+
+.panel--footer {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.field-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 14px;
+}
+
+.text-input {
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid #d1d5db;
+    font-size: 14px;
+}
+
+.text-input:focus {
+    outline: none;
+    border-color: #4f46e5;
+    box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
+}
+
+.checkbox {
+    width: 20px;
+    height: 20px;
+}
+
+.mapping-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 16px;
+    margin-top: 16px;
+    background: #f9fafb;
+}
+
+.mapping-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.button {
+    border: none;
+    padding: 10px 16px;
+    border-radius: 8px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.button--primary {
+    background: #4f46e5;
+    color: #fff;
+}
+
+.button--secondary {
+    background: #eef2ff;
+    color: #4338ca;
+}
+
+.button--danger {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.status {
+    font-size: 14px;
+}
+
+.status--success {
+    color: #047857;
+}
+
+.status--error {
+    color: #b91c1c;
+}
+
+ul.validation-errors {
+    margin: 0;
+    padding-left: 18px;
+    color: #b91c1c;
+}

--- a/LoxNet.Bridge/tests/Bridge.Tests/DedupingTests.cs
+++ b/LoxNet.Bridge/tests/Bridge.Tests/DedupingTests.cs
@@ -20,7 +20,7 @@ public class DedupingTests
     [Fact]
     public async Task MqttEchoIsSuppressed()
     {
-        var config = new BridgeConfig { Mappings = new[] { _mapping } };
+        var config = new BridgeConfig { Mappings = new List<MappingSection> { _mapping } };
         var cache = new StateCache();
         var comparer = new StateComparer(config);
         var fakeLoxone = new FakeLoxoneExecutor();
@@ -38,7 +38,7 @@ public class DedupingTests
     [Fact]
     public async Task LoxoneEchoIsSuppressed()
     {
-        var config = new BridgeConfig { Mappings = new[] { _mapping } };
+        var config = new BridgeConfig { Mappings = new List<MappingSection> { _mapping } };
         var cache = new StateCache();
         var comparer = new StateComparer(config);
         var fakeLoxone = new FakeLoxoneExecutor();

--- a/LoxNet.Bridge/tests/Bridge.Tests/LoxNet.Bridge.Tests.csproj
+++ b/LoxNet.Bridge/tests/Bridge.Tests/LoxNet.Bridge.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/LoxNet.Client/LoxNet.Client.csproj
+++ b/LoxNet.Client/LoxNet.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;net48</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/LoxNet.Client/LoxoneClient.cs
+++ b/LoxNet.Client/LoxoneClient.cs
@@ -110,7 +110,11 @@ public class LoxoneClient : ILoxoneClient
             {
                 return await _inner.RequestJsonAsync(path, cancellationToken).ConfigureAwait(false);
             }
+#if NET48
+            catch (HttpRequestException ex) when (ex.Message.Contains("401"))
+#else
             catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+#endif
             {
                 await _parent.EnsureValidTokenAsync(cancellationToken).ConfigureAwait(false);
                 return await _inner.RequestJsonAsync(path, cancellationToken).ConfigureAwait(false);

--- a/LoxNet.Client/LoxoneHttpClient.cs
+++ b/LoxNet.Client/LoxoneHttpClient.cs
@@ -48,7 +48,11 @@ public class LoxoneHttpClient : ILoxoneHttpClient
     {
         using var resp = await _http.GetAsync($"{BaseUrl}/{path}", cancellationToken).ConfigureAwait(false);
         resp.EnsureSuccessStatusCode();
+#if NET48
+        var stream = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
         var stream = await resp.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
         return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 

--- a/LoxNet.sln
+++ b/LoxNet.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoxNet.Client", "LoxNet.Client\LoxNet.Client.csproj", "{45EE941B-6DFC-451B-172F-03031C703FD3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoxNet.Tests", "LoxNet.Tests\LoxNet.Tests.csproj", "{59B8FE45-B199-EF05-BEC6-6D09433A2E71}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{45EE941B-6DFC-451B-172F-03031C703FD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45EE941B-6DFC-451B-172F-03031C703FD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45EE941B-6DFC-451B-172F-03031C703FD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45EE941B-6DFC-451B-172F-03031C703FD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59B8FE45-B199-EF05-BEC6-6D09433A2E71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59B8FE45-B199-EF05-BEC6-6D09433A2E71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59B8FE45-B199-EF05-BEC6-6D09433A2E71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59B8FE45-B199-EF05-BEC6-6D09433A2E71}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B00A8C0C-777F-4CB5-A6B3-711CB85CBC9D}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
### Motivation

- Provide a simple front-end to configure the Loxone miniserver, MQTT broker, and mapping rules for the bridge.
- Allow editing and persisting the bridge YAML configuration at runtime via the bridge process.
- Make it easier to discover and assign Loxone subcontrols to MQTT topics through a web UI.

### Description

- Adds a Blazor UI under `LoxNet.Bridge/src/Bridge/Ui` including `App.razor`, layout, `ConfigPage.razor`, models, `_Imports.razor`, and `wwwroot/app.css` to render and edit configuration.
- Introduces API DTOs and mapping helpers in `Api/BridgeConfigDto.cs` and `Api/BridgeConfigMapper.cs`, YAML serializer `ConfigYamlSerializer.cs`, and `ConfigFileSettings` to store the config file path.
- Exposes config endpoints in `MinimalApiHost`: `GET /config` returns the current config DTO and `POST /config` validates and writes YAML using `ConfigYamlSerializer`, and registers Razor components via `MapRazorComponents`.
- Refactors `ConfigLoader` to add `ResolvePath` and wires the resolved path into `Program.cs` to register `ConfigFileSettings` for persistence.

### Testing

- Ran `dotnet run --project LoxNet.Bridge/src/Bridge/Bridge.csproj` to smoke-test the host startup and web UI integration, which attempted to start the app but the build failed.
- The build failure was due to a missing project reference to `LoxNet.Client` and an `MQTTnet` package version mismatch causing compilation errors in MQTT types, so the run did not complete successfully.
- No unit test suite was executed as part of this change in this environment due to the build errors reported above.
- The new code was compiled locally up to the build failure and committed (13 files added/changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a07a47e08832693c53f1bd6b83a76)